### PR TITLE
Add a benchmark to compare cbor2 vs stdlib json

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+from operator import attrgetter
+
+Contender = namedtuple('Contender', 'name,dumps,loads')
+
+contenders = []
+
+import json
+contenders.append(Contender('json', json.dumps, json.loads))
+
+import cbor2
+contenders.append(Contender('cbor2', cbor2.dumps, cbor2.loads))
+
+
+# See https://github.com/ionelmc/pytest-benchmark/issues/48
+
+def pytest_benchmark_group_stats(config, benchmarks, group_by):
+    result = {}
+    for bench in benchmarks:
+        engine, data_kind = bench.param.split('-')
+        group = result.setdefault("%s: %s" % (data_kind, bench.group), [])
+        group.append(bench)
+    return sorted(result.items())
+
+def pytest_generate_tests(metafunc):
+    if 'contender' in metafunc.fixturenames:
+        metafunc.parametrize('contender', contenders, ids=attrgetter('name'))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,86 @@
+from random import randint, random
+from sys import maxsize
+
+import pytest
+
+
+composite_object = {
+    'words': """
+        Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit. Mauris adipiscing adipiscing placerat.
+        Vestibulum augue augue,
+        pellentesque quis sollicitudin id, adipiscing.
+        """,
+    'list': list(range(200)),
+    'dict': dict((str(i),'a') for i in list(range(200))),
+    'int': 100100100,
+    'float': 100999.123456
+}
+
+user = {
+    "userId": 3381293,
+    "age": 213,
+    "username": "johndoe",
+    "fullname": u"John Doe the Second",
+    "isAuthorized": True,
+    "liked": 31231.31231202,
+    "approval": 31.1471,
+    "jobs": [ 1, 2 ],
+    "currJob": None
+}
+
+friends = [ user, user, user, user, user, user, user, user ]
+
+doubles = []
+numbers = []
+unicode_strings = []
+strings = []
+booleans = []
+datetimes = []
+list_dicts = []
+dict_lists = {}
+
+complex_object = [
+    [user, friends],  [user, friends],  [user, friends],
+    [user, friends],  [user, friends],  [user, friends]
+]
+
+for x in range(256):
+    doubles.append(maxsize * random())
+    numbers.append(maxsize * random())
+    numbers.append(randint(0, maxsize))
+    unicode_strings.append("نظام الحكم سلطاني وراثي في الذكور من ذرية السيد تركي بن سعيد بن سلطان ويشترط فيمن يختار لولاية الحكم من بينهم ان يكون مسلما رشيدا عاقلا ًوابنا شرعيا لابوين عمانيين ")
+    strings.append("A pretty long string which is in a list")
+    booleans.append(True)
+
+for y in range(100):
+    arrays = []
+    list_dicts.append({str(random()*20): int(random()*1000000)})
+
+    for x in range(100):
+        arrays.append({str(random() * 20): int(random()*1000000)})
+        dict_lists[str(random() * 20)] = arrays
+
+
+datasets = [('composite object', composite_object),
+            ('256 doubles array', doubles),
+            ('256 unicode array', unicode_strings),
+            ('256 ASCII array', strings),
+            ('256 Trues array', booleans),
+            ('100 dicts array', list_dicts),
+            ('100 arrays dict', dict_lists),
+            ('complex object', complex_object),
+]
+
+
+@pytest.mark.benchmark(group='serialize')
+@pytest.mark.parametrize('data', [d[1] for d in datasets], ids=[d[0] for d in datasets])
+def test_dumps(contender, data, benchmark):
+    benchmark(contender.dumps, data)
+
+
+@pytest.mark.benchmark(group='deserialize')
+@pytest.mark.parametrize('data', [d[1] for d in datasets], ids=[d[0] for d in datasets])
+def test_loads(contender, data, benchmark):
+    data = contender.dumps(data)
+    benchmark(contender.loads, data)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ pypy = pypy
 
 [testenv]
 commands = python -m pytest {posargs}
-deps = pytest
+deps =
+    pytest
+    pytest-benchmark
     pytest-cov
 
 [testenv:flake8]


### PR DESCRIPTION
This produces something like
```
------------------------------------------------------------------- benchmark '100 arrays dict: deserialize': 2 tests --------------------------------------------------------------------
Name (time in ms)                          Min                 Max                Mean             StdDev              Median               IQR            Outliers(*)  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_loads[cbor2-100 arrays dict]     126.2084 (1.0)      135.6891 (1.0)      127.7965 (1.0)       3.2050 (1.0)      126.7133 (1.0)      0.6334 (1.0)              1;1       8           1
test_loads[json-100 arrays dict]      455.5744 (3.61)     486.9637 (3.59)     475.8448 (3.72)     11.8648 (3.70)     478.8540 (3.78)     8.7094 (13.75)            1;1       5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

for several different dataset. It could be used to reason about possible Cython speedups...