### PR TITLE
Fix for #15

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -87,10 +87,20 @@ def decode_map(decoder, subtype, shareable_index=None):
     dictionary = {}
     decoder.set_shareable(shareable_index, dictionary)
     length = decode_uint(decoder, subtype, allow_indefinite=True)
+
+    def make_hashable(key):
+        # Handle arrays and indefinite-length bytestrings used as
+        # keys
+        if type(key) is list:
+            return tuple(key)
+        elif type(key) is bytearray:
+            return bytes(key)
+        else:
+            return key
     if length is None:
         # Indefinite length
         while True:
-            key = decoder.decode()
+            key = make_hashable(decoder.decode())
             if key is break_marker:
                 break
             else:
@@ -98,7 +108,7 @@ def decode_map(decoder, subtype, shareable_index=None):
                 dictionary[key] = value
     else:
         for _ in xrange(length):
-            key = decoder.decode()
+            key = make_hashable(decoder.decode())
             value = decoder.decode()
             dictionary[key] = value
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -126,7 +126,8 @@ def test_array(payload, expected):
 @pytest.mark.parametrize('payload, expected', [
     ('a0', {}),
     ('a201020304', {1: 2, 3: 4}),
-    ('A18201026178', {(1, 2): 'x'})
+    ('A18201026178', {(1, 2): 'x'}),
+    ('a15f4178ff4179', {b'x': b'y'})
 ])
 def test_map(payload, expected):
     decoded = loads(unhexlify(payload))

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -125,7 +125,8 @@ def test_array(payload, expected):
 
 @pytest.mark.parametrize('payload, expected', [
     ('a0', {}),
-    ('a201020304', {1: 2, 3: 4})
+    ('a201020304', {1: 2, 3: 4}),
+    ('A18201026178', {(1, 2): 'x'})
 ])
 def test_map(payload, expected):
     decoded = loads(unhexlify(payload))

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -258,3 +258,7 @@ def test_dump_to_file(tmpdir):
         dump([1, 10], fp)
 
     assert path.read_binary() == b'\x82\x01\x0a'
+
+
+def test_tuple_key():
+    assert dumps({(2, 1): u''}) == unhexlify('a182020160')


### PR DESCRIPTION
Although encoding a map key as an indefinite length anything seems a bit unlikely I thought I should cover the possibility.