### PR TITLE
Raise EOFError if EOF is encountered on read

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -351,11 +351,16 @@ class CBORDecoder(object):
         """
         Decode the next value from the stream.
 
+        :raises EOFError: if EOF is encountered while reading
         :raises CBORDecodeError: if there is any problem decoding the stream
 
         """
+        byte = self.fp.read(1)
+        if not byte:
+            raise EOFError()
+
         try:
-            initial_byte = byte_as_integer(self.fp.read(1))
+            initial_byte = byte_as_integer(byte)
             major_type = initial_byte >> 5
             subtype = initial_byte & 31
         except Exception as e:


### PR DESCRIPTION
This allows to distinguish actual decoding errors from EOF when decoding files containing multiple objects. Also fixes #12.
