### PR TITLE
Problem: Bug #15, CBOR maps can contain unhashable types as keys

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -1,10 +1,11 @@
 import re
 import struct
 from datetime import datetime, timedelta
+from contextlib import contextmanager
 from io import BytesIO
 
-from .compat import timezone, xrange, byte_as_integer, unpack_float16
-from .types import CBORTag, undefined, break_marker, CBORSimpleValue
+from cbor2.compat import timezone, xrange, byte_as_integer, unpack_float16
+from cbor2.types import CBORTag, undefined, break_marker, CBORSimpleValue, HashableMap
 
 timestamp_re = re.compile(r'^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)'
                           r'(?:\.(\d+))?(?:Z|([+-]\d\d):(\d\d))$')
@@ -43,15 +44,15 @@ def decode_bytestring(decoder, subtype, shareable_index=None):
     length = decode_uint(decoder, subtype, allow_indefinite=True)
     if length is None:
         # Indefinite length
-        buf = bytearray()
+        buf = []
         while True:
             initial_byte = byte_as_integer(decoder.read(1))
             if initial_byte == 255:
-                return buf
+                return b''.join(buf)
             else:
                 length = decode_uint(decoder, initial_byte & 31)
                 value = decoder.read(length)
-                buf.extend(value)
+                buf.append(value)
     else:
         return decoder.read(length)
 
@@ -79,7 +80,10 @@ def decode_array(decoder, subtype, shareable_index=None):
             item = decoder.decode()
             items.append(item)
 
-    return items
+    if decoder._hashable:
+        return tuple(items)
+    else:
+        return items
 
 
 def decode_map(decoder, subtype, shareable_index=None):
@@ -90,7 +94,8 @@ def decode_map(decoder, subtype, shareable_index=None):
     if length is None:
         # Indefinite length
         while True:
-            key = decoder.decode()
+            with decoder.key_decoder() as decode:
+                key = decode()
             if key is break_marker:
                 break
             else:
@@ -98,12 +103,15 @@ def decode_map(decoder, subtype, shareable_index=None):
                 dictionary[key] = value
     else:
         for _ in xrange(length):
-            key = decoder.decode()
+            with decoder.key_decoder() as decode:
+                key = decode()
             value = decoder.decode()
             dictionary[key] = value
 
     if decoder.object_hook:
         return decoder.object_hook(decoder, dictionary)
+    elif decoder._hashable:
+        return HashableMap(dictionary)
     else:
         return dictionary
 
@@ -117,7 +125,13 @@ def decode_semantic(decoder, subtype, shareable_index=None):
         shareable_index = decoder._allocate_shareable()
         return decoder.decode(shareable_index)
 
-    value = decoder.decode()
+    # Special handling for sets
+    if tagnum == 258:
+        with decoder.key_decoder() as decode:
+            value = decode()
+    else:
+        value = decoder.decode()
+
     semantic_decoder = semantic_decoders.get(tagnum)
     if semantic_decoder:
         return semantic_decoder(decoder, value, shareable_index)
@@ -228,7 +242,10 @@ def decode_uuid(decoder, value, shareable_index=None):
 
 def decode_set(decoder, value, shareable_index=None):
     # Semantic tag 258
-    return set(value)
+    if decoder._hashable:
+        return frozenset(value)
+    else:
+        return set(value)
 
 
 #
@@ -304,13 +321,14 @@ class CBORDecoder(object):
         The return value is substituted for the dict in the deserialized output.
     """
 
-    __slots__ = ('fp', 'tag_hook', 'object_hook', '_shareables')
+    __slots__ = ('fp', 'tag_hook', 'object_hook', '_shareables', '_hashable')
 
     def __init__(self, fp, tag_hook=None, object_hook=None):
         self.fp = fp
         self.tag_hook = tag_hook
         self.object_hook = object_hook
         self._shareables = []
+        self._hashable = False
 
     def _allocate_shareable(self):
         self._shareables.append(None)
@@ -380,6 +398,16 @@ class CBORDecoder(object):
         retval = self.decode()
         self.fp = old_fp
         return retval
+
+    @contextmanager
+    def key_decoder(self):
+        """
+        Forces decoders that return mutable types by default to produce hashable types.
+        """
+        original_flag = self._hashable
+        self._hashable = True
+        yield self.decode
+        self._hashable = original_flag
 
 
 def loads(payload, **kwargs):

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -111,7 +111,7 @@ def decode_map(decoder, subtype, shareable_index=None):
     if decoder.object_hook:
         return decoder.object_hook(decoder, dictionary)
     elif decoder._immutable:
-        return FrozenDict.supply_dict(dictionary)
+        return FrozenDict(dictionary)
     else:
         return dictionary
 

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -80,7 +80,7 @@ def decode_array(decoder, subtype, shareable_index=None):
             item = decoder.decode()
             items.append(item)
 
-    if decoder._immutable:
+    if decoder.immutable:
         return tuple(items)
     else:
         return items
@@ -110,7 +110,7 @@ def decode_map(decoder, subtype, shareable_index=None):
 
     if decoder.object_hook:
         return decoder.object_hook(decoder, dictionary)
-    elif decoder._immutable:
+    elif decoder.immutable:
         return FrozenDict(dictionary)
     else:
         return dictionary
@@ -242,7 +242,7 @@ def decode_uuid(decoder, value, shareable_index=None):
 
 def decode_set(decoder, value, shareable_index=None):
     # Semantic tag 258
-    if decoder._immutable:
+    if decoder.immutable:
         return frozenset(value)
     else:
         return set(value)
@@ -329,6 +329,15 @@ class CBORDecoder(object):
         self.object_hook = object_hook
         self._shareables = []
         self._immutable = False
+
+    @property
+    def immutable(self):
+        """
+        Used by decoders to check if the calling context requires an immutable type.
+        Object_hook or tag_hook should raise an exception if this flag is set unless
+        the result can be safely used as a dict key.
+        """
+        return self._immutable
 
     def _allocate_shareable(self):
         self._shareables.append(None)

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta
 from contextlib import contextmanager
 from io import BytesIO
 
-from cbor2.compat import timezone, xrange, byte_as_integer, unpack_float16
-from cbor2.types import CBORTag, undefined, break_marker, CBORSimpleValue, FrozenDict
+from .compat import timezone, xrange, byte_as_integer, unpack_float16
+from .types import CBORTag, undefined, break_marker, CBORSimpleValue, FrozenDict
 
 timestamp_re = re.compile(r'^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)'
                           r'(?:\.(\d+))?(?:Z|([+-]\d\d):(\d\d))$')

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -55,22 +55,10 @@ class FrozenDict(Mapping):
 
     The arguments to ``FrozenDict`` are processed just like those to ``dict``.
     """
+
     def __init__(self, *args, **kwargs):
         self._d = dict(*args, **kwargs)
         self._hash = None
-
-    @classmethod
-    def supply_dict(cls, d):
-        """
-        When called from decode_map we can safely supply the internal dict
-        directly.
-
-        We can guarantee that only immutable pairs have been used to
-        construct this dictionary.
-        """
-        frozen_dict = cls()
-        frozen_dict._d = d
-        return frozen_dict
 
     def __iter__(self):
         return iter(self._d)

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -50,7 +50,7 @@ class HashableMap(dict):
     """
     Allows Mapping types to be used as map keys.
     """
-    
+
     def __hash__(self):
             return hash((frozenset(self), frozenset(self.values())))
 

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -46,6 +46,15 @@ class CBORSimpleValue(object):
         return 'CBORSimpleValue({self.value})'.format(self=self)
 
 
+class HashableMap(dict):
+    """
+    Allows Mapping types to be used as map keys.
+    """
+    
+    def __hash__(self):
+            return hash((frozenset(self), frozenset(self.values())))
+
+
 class UndefinedType(object):
     __slots__ = ()
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -130,3 +130,32 @@ You could then verify that the cyclic references have been restored after deseri
     assert new_parent.children[0].parent is new_parent
     assert new_parent.children[1].parent is new_parent
 
+Decoding Tagged items as keys
+-----------------------------
+
+Since the CBOR specification allows any type to be used as a key in the mapping type, the decoder
+provides a flag that indicates it is expecting an immutable (and by implication hashable) type. If
+your custom class cannot be used this way you can raise an exception if this flag is set::
+
+    def tag_hook(decoder, tag, shareable_index=None):
+        if tag.tag != 3000:
+            return tag
+
+        if decoder.immutable:
+            raise CBORDecodeException('MyType cannot be used as a key or set member')
+
+        return MyType(*tag.value)
+
+An example where the data could be used as a dict key::
+
+    from collections import namedtuple
+
+    Pair = namedtuple('Pair', 'first second')
+
+    def tag_hook(decoder, tag, shareable_index=None):
+        if tag.tag != 4000:
+            return tag
+
+        return Pair(*tag.value)
+
+The ``object_hook`` can check for the immutable flag in the same way.

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -344,6 +344,7 @@ def test_set():
 
 @pytest.mark.parametrize('payload, expected', [
     ('a1a1616161626163', {FrozenDict({'a': 'b'}): 'c'}),
+    ('A1A1A10101A1666E6573746564F56176', {FrozenDict({FrozenDict({1:1}): FrozenDict({"nested":True})}): "v"}),
     ('a182010203', {(1, 2): 3}),
     ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
     ('A17f657374726561646d696e67ff01', {"streaming": 1}),

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -15,7 +15,7 @@ import pytest
 
 from cbor2.compat import timezone
 from cbor2.decoder import loads, CBORDecodeError, load, CBORDecoder
-from cbor2.types import CBORTag, undefined, CBORSimpleValue
+from cbor2.types import CBORTag, undefined, CBORSimpleValue, HashableMap
 
 
 @pytest.mark.parametrize('payload, expected', [
@@ -340,3 +340,16 @@ def test_set():
     value = loads(payload)
     assert type(value) is set
     assert value == set([u'a', u'b', u'c'])
+
+
+@pytest.mark.parametrize('payload, expected', [
+    ('a1a1616161626163', {HashableMap({'a':'b'}): 'c'}),
+    ('a182010203', {(1, 2): 3}),
+    ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
+    ('A17f657374726561646d696e67ff01', {"streaming": 1}),
+    ('d9010282d90102820102d90102820304', {frozenset({1, 2}), frozenset({3,4})})
+])
+def test_hashable_keys(payload, expected):
+    value = loads(unhexlify(payload))
+    assert value == expected
+

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -344,7 +344,8 @@ def test_set():
 
 @pytest.mark.parametrize('payload, expected', [
     ('a1a1616161626163', {FrozenDict({'a': 'b'}): 'c'}),
-    ('A1A1A10101A1666E6573746564F5A1666E6573746564F4', {FrozenDict({FrozenDict({1:1}): FrozenDict({"nested":True})}): {"nested":False}}),
+    ('A1A1A10101A1666E6573746564F5A1666E6573746564F4',
+        {FrozenDict({FrozenDict({1: 1}): FrozenDict({"nested": True})}): {"nested": False}}),
     ('a182010203', {(1, 2): 3}),
     ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
     ('A17f657374726561646d696e67ff01', {"streaming": 1}),

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -15,7 +15,7 @@ import pytest
 
 from cbor2.compat import timezone
 from cbor2.decoder import loads, CBORDecodeError, load, CBORDecoder
-from cbor2.types import CBORTag, undefined, CBORSimpleValue, HashableMap
+from cbor2.types import CBORTag, undefined, CBORSimpleValue, FrozenDict
 
 
 @pytest.mark.parametrize('payload, expected', [
@@ -343,12 +343,12 @@ def test_set():
 
 
 @pytest.mark.parametrize('payload, expected', [
-    ('a1a1616161626163', {HashableMap({'a': 'b'}): 'c'}),
+    ('a1a1616161626163', {FrozenDict({'a': 'b'}): 'c'}),
     ('a182010203', {(1, 2): 3}),
     ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
     ('A17f657374726561646d696e67ff01', {"streaming": 1}),
     ('d9010282d90102820102d90102820304', {frozenset({1, 2}), frozenset({3, 4})})
 ])
-def test_hashable_keys(payload, expected):
+def test_immutable_keys(payload, expected):
     value = loads(unhexlify(payload))
     assert value == expected

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -343,13 +343,12 @@ def test_set():
 
 
 @pytest.mark.parametrize('payload, expected', [
-    ('a1a1616161626163', {HashableMap({'a':'b'}): 'c'}),
+    ('a1a1616161626163', {HashableMap({'a': 'b'}): 'c'}),
     ('a182010203', {(1, 2): 3}),
     ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
     ('A17f657374726561646d696e67ff01', {"streaming": 1}),
-    ('d9010282d90102820102d90102820304', {frozenset({1, 2}), frozenset({3,4})})
+    ('d9010282d90102820102d90102820304', {frozenset({1, 2}), frozenset({3, 4})})
 ])
 def test_hashable_keys(payload, expected):
     value = loads(unhexlify(payload))
     assert value == expected
-

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -344,7 +344,7 @@ def test_set():
 
 @pytest.mark.parametrize('payload, expected', [
     ('a1a1616161626163', {FrozenDict({'a': 'b'}): 'c'}),
-    ('A1A1A10101A1666E6573746564F56176', {FrozenDict({FrozenDict({1:1}): FrozenDict({"nested":True})}): "v"}),
+    ('A1A1A10101A1666E6573746564F5A1666E6573746564F4', {FrozenDict({FrozenDict({1:1}): FrozenDict({"nested":True})}): {"nested":False}}),
     ('a182010203', {(1, 2): 3}),
     ('a1d901028301020304', {frozenset({1, 2, 3}): 4}),
     ('A17f657374726561646d696e67ff01', {"streaming": 1}),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cbor2.types import CBORTag, CBORSimpleValue
+from cbor2.types import CBORTag, CBORSimpleValue, FrozenDict
 
 
 def test_tag_repr():
@@ -34,3 +34,8 @@ def test_simple_value_equals():
 def test_simple_value_too_big():
     exc = pytest.raises(TypeError, CBORSimpleValue, 256)
     assert str(exc.value) == 'simple value too big'
+
+
+def test_frozendict():
+    assert len(FrozenDict({1: 2, 3: 4})) ==  2
+    assert repr(FrozenDict({1: 2})) == "FrozenDict({1: 2})"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,5 +37,5 @@ def test_simple_value_too_big():
 
 
 def test_frozendict():
-    assert len(FrozenDict({1: 2, 3: 4})) ==  2
+    assert len(FrozenDict({1: 2, 3: 4})) == 2
     assert repr(FrozenDict({1: 2})) == "FrozenDict({1: 2})"


### PR DESCRIPTION
Solution: Use a context manager for decoding keys and set items which
makes sure to use a hashable type.

Also indefinite length bytestring decoding returns bytes() instead of
bytearray().