### PR TITLE
Fix for #26: handle overflow exceptions properly...

### DIFF
--- a/cbor2/compat.py
+++ b/cbor2/compat.py
@@ -55,20 +55,21 @@ if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
     # Python 3.6 added 16 bit floating point to struct
 
     def pack_float16(value):
-        try:
-            return struct.pack('>Be', 0xf9, value)
-        except OverflowError:
-            return False
+        pass
 
     def unpack_float16(payload):
-        return struct.unpack('>e', payload)[0]
+        pass
+
 else:
     def pack_float16(value):
         # Based on node-cbor by hildjj
         # which was based in turn on Carsten Borman's cn-cbor
-        u32 = struct.pack('>f', value)
-        u = struct.unpack('>I', u32)[0]
+        try:
+            u32 = struct.pack('>f', value)
+        except OverflowError:
+            return False
 
+        u = struct.unpack('>I', u32)[0]
         if u & 0x1FFF != 0:
             return False
 

--- a/cbor2/compat.py
+++ b/cbor2/compat.py
@@ -51,7 +51,7 @@ else:
     bytes_from_list = bytes
 
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:  # pragma: no cover
     # Python 3.6 added 16 bit floating point to struct
 
     def pack_float16(value):

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -258,7 +258,11 @@ def decode_simple_value(decoder, shareable_index=None):
 
 def decode_float16(decoder, shareable_index=None):
     payload = decoder.read(2)
-    return unpack_float16(payload)
+    try:
+        value = struct.unpack('>e', payload)[0]
+    except struct.error:
+        value = unpack_float16(payload)
+    return value
 
 
 def decode_float32(decoder, shareable_index=None):

--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -239,16 +239,21 @@ def encode_minimal_float(encoder, value):
     elif math.isinf(value):
         encoder.write(b'\xf9\x7c\x00' if value > 0 else b'\xf9\xfc\x00')
     else:
-        encoded = struct.pack('>Bf', 0xfa, value)
-        if struct.unpack('>Bf', encoded)[1] != value:
-            encoded = struct.pack('>Bd', 0xfb, value)
-            encoder.write(encoded)
-        else:
-            f16 = pack_float16(value)
-            if f16 and unpack_float16(f16[1:]) == value:
-                encoder.write(f16)
-            else:
-                encoder.write(encoded)
+        # Try each encoding in turn from shortest to longest
+        for format, tag in [('>Be', 0xf9), ('>Bf', 0xfa), ('>Bd', 0xfb)]:
+            try:
+                encoded = struct.pack(format, tag, value)
+                # Check if encoding as low-byte float loses precision
+                if struct.unpack(format, encoded)[1] == value:
+                    break
+            except struct.error:
+                # Catch the case where the 'e' format is not supported
+                encoded = pack_float16(value)
+                if encoded and unpack_float16(encoded[1:]) == value:
+                    break
+            except OverflowError:
+                pass
+        encoder.write(encoded)
 
 
 def encode_boolean(encoder, value):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -276,7 +276,7 @@ def test_premature_end_of_stream():
 
     """
     exc = pytest.raises(CBORDecodeError, loads, unhexlify('437879'))
-    exc.match('premature end of stream \(expected to read 3 bytes, got 2 instead\)')
+    exc.match(r'premature end of stream \(expected to read 3 bytes, got 2 instead\)')
 
 
 def test_tag_hook():

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -286,10 +286,11 @@ def test_ordered_map(value, expected):
     (float('-inf'), 'f9fc00'),
     (float.fromhex('0x1.0p-24'), 'f90001'),
     (float.fromhex('0x1.4p-24'), 'fa33a00000'),
-    (float.fromhex('0x1.ff8p-63'), 'fa207fc000')
+    (float.fromhex('0x1.ff8p-63'), 'fa207fc000'),
+    (1e300, 'fb7e37e43c8800759c')
 ], ids=['float 16', 'float 32', 'float 64', 'inf', 'nan', '-inf',
         'float 16 minimum positive subnormal', 'mantissa o/f to 32',
-        'exponent o/f to 32'])
+        'exponent o/f to 32', 'oversize float'])
 def test_minimal_floats(value, expected):
     expected = unhexlify(expected)
     assert dumps(value, canonical=True) == expected

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from binascii import unhexlify
 from collections import OrderedDict
 from datetime import datetime, timedelta, date
@@ -9,7 +10,7 @@ from uuid import UUID
 
 import pytest
 
-from cbor2.compat import timezone
+from cbor2.compat import timezone, pack_float16
 from cbor2.encoder import dumps, CBOREncodeError, dump, shareable_encoder
 from cbor2.types import CBORTag, undefined, CBORSimpleValue, FrozenDict
 
@@ -323,3 +324,23 @@ def test_canonical_set(frozen):
 
     serialized = dumps(value, canonical=True)
     assert serialized == unhexlify('d9010284616161786179626161')
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 6), reason="Using native struct.pack")
+@pytest.mark.parametrize('value, expected', [
+    (3.5, 'F94300'),
+    (100000.0,  False),
+    (3.8, False),
+    (float.fromhex('0x1.0p-24'), 'f90001'),
+    (float.fromhex('0x1.4p-24'), False),
+    (float.fromhex('0x1.ff8p-63'), False),
+    (1e300, False)
+], ids=['float 16', 'float 32', 'float 64',
+        'float 16 minimum positive subnormal', 'mantissa o/f to 32',
+        'exponent o/f to 32', 'oversize float'])
+def test_float16_encoder(value, expected):
+    if expected:
+        expected = unhexlify(expected)
+        assert pack_float16(value) == expected
+    else:
+        assert not pack_float16(value)


### PR DESCRIPTION
...and try a better encoding.

I decided to make it explicit and always try to use the proper struct.pack format and only use the pack/unpack_float16 if there's an exception.

Using canonical encoding with lots of floating point data in python<3.6 will be very slow.

Follows reccommendation in CBOR spec:

https://tools.ietf.org/html/draft-ietf-cbor-7049bis-04#page-32

>   If a protocol allows for IEEE floats, then additional
>   canonicalization rules might need to be added.  One example rule
>   might be to have all floats start as a 64-bit float, then do a test
>   conversion to a 32-bit float; if the result is the same numeric
>   value, use the shorter value and repeat the process with a test
>   conversion to a 16-bit float.  (This rule selects 16-bit float for
>   positive and negative Infinity as well.)  Also, there are many
>   representations for NaN.  If NaN is an allowed value, it must always
>   be represented as 0xf97e00.