### PR TITLE
Fix DeprecationWarning under Python 3.7

### DIFF
--- a/cbor2/compat.py
+++ b/cbor2/compat.py
@@ -4,7 +4,7 @@ import sys
 
 
 if sys.version_info.major < 3:
-    from collections import Mapping
+    from collections import Mapping  # noqa: F401
     from datetime import tzinfo, timedelta
     from binascii import unhexlify
 
@@ -39,7 +39,7 @@ if sys.version_info.major < 3:
     long = long  # noqa: F821
     unicode = unicode  # noqa: F821
 else:
-    from collections.abc import Mapping
+    from collections.abc import Mapping  # noqa: F401
     from datetime import timezone
 
     def byte_as_integer(bytestr):

--- a/cbor2/compat.py
+++ b/cbor2/compat.py
@@ -4,6 +4,7 @@ import sys
 
 
 if sys.version_info.major < 3:
+    from collections import Mapping
     from datetime import tzinfo, timedelta
     from binascii import unhexlify
 
@@ -38,6 +39,7 @@ if sys.version_info.major < 3:
     long = long  # noqa: F821
     unicode = unicode  # noqa: F821
 else:
+    from collections.abc import Mapping
     from datetime import timezone
 
     def byte_as_integer(bytestr):

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -1,5 +1,6 @@
 from .compat import Mapping
 
+
 class CBORTag(object):
     """
     Represents a CBOR semantic tag.

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -1,5 +1,4 @@
-from collections import Mapping
-
+from .compat import Mapping
 
 class CBORTag(object):
     """


### PR DESCRIPTION
Fixes the following deprecation warning in Python 3.7:

> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
