### PR TITLE
Don't encode dates as datetimes by default

### DIFF
--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -66,6 +66,9 @@ class CBOREncoder(object):
         when True, use "canonical" CBOR representation; this typically involves
         sorting maps, sets, etc. into a pre-determined order ensuring that
         serializations are comparable without decoding
+    :param bool date_as_datetime: set to ``True`` to serialize date objects as
+        datetimes (CBOR tag 0), which was the default behavior in previous
+        releases (cbor2 <= 4.1.2).
 
     .. _CBOR: https://cbor.io/
     """
@@ -76,7 +79,8 @@ class CBOREncoder(object):
         '_canonical')
 
     def __init__(self, fp, datetime_as_timestamp=False, timezone=None,
-                 value_sharing=False, default=None, canonical=False):
+                 value_sharing=False, default=None, canonical=False,
+                 date_as_datetime=False):
         self.fp = fp
         self.datetime_as_timestamp = datetime_as_timestamp
         self.timezone = timezone
@@ -87,6 +91,8 @@ class CBOREncoder(object):
         self._encoders = default_encoders.copy()
         if canonical:
             self._encoders.update(canonical_encoders)
+        if date_as_datetime:
+            self._encoders[date] = CBOREncoder.encode_date
 
     def _find_encoder(self, obj_type):
         for type_, enc in list(iteritems(self._encoders)):
@@ -471,7 +477,6 @@ default_encoders = OrderedDict([
     (FrozenDict,                    CBOREncoder.encode_map),
     (type(undefined),               CBOREncoder.encode_undefined),
     (datetime,                      CBOREncoder.encode_datetime),
-    (date,                          CBOREncoder.encode_date),
     (type(re.compile('')),          CBOREncoder.encode_regexp),
     (('fractions', 'Fraction'),     CBOREncoder.encode_rational),
     (('email.message', 'Message'),  CBOREncoder.encode_mime),

--- a/source/module.c
+++ b/source/module.c
@@ -601,6 +601,7 @@ PyObject *_CBOR2_str_datestr_re = NULL;
 PyObject *_CBOR2_str_Decimal = NULL;
 PyObject *_CBOR2_str_default_encoders = NULL;
 PyObject *_CBOR2_str_denominator = NULL;
+PyObject *_CBOR2_str_encode_date = NULL;
 PyObject *_CBOR2_str_Fraction = NULL;
 PyObject *_CBOR2_str_fromtimestamp = NULL;
 PyObject *_CBOR2_str_FrozenDict = NULL;
@@ -861,6 +862,7 @@ PyInit__cbor2(void)
     INTERN_STRING(Decimal);
     INTERN_STRING(default_encoders);
     INTERN_STRING(denominator);
+    INTERN_STRING(encode_date);
     INTERN_STRING(Fraction);
     INTERN_STRING(fromtimestamp);
     INTERN_STRING(FrozenDict);

--- a/source/module.h
+++ b/source/module.h
@@ -43,6 +43,7 @@ extern PyObject *_CBOR2_str_datestr_re;
 extern PyObject *_CBOR2_str_Decimal;
 extern PyObject *_CBOR2_str_default_encoders;
 extern PyObject *_CBOR2_str_denominator;
+extern PyObject *_CBOR2_str_encode_date;
 extern PyObject *_CBOR2_str_Fraction;
 extern PyObject *_CBOR2_str_fromtimestamp;
 extern PyObject *_CBOR2_str_FrozenDict;

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -236,8 +236,13 @@ def test_datetime(impl, value, as_timestamp, expected):
 
 
 def test_date(impl):
+    with pytest.raises(impl.CBOREncodeError):
+        impl.dumps(date(2013, 3, 21))
+
+
+def test_date_as_datetime(impl):
     expected = unhexlify('c074323031332d30332d32315430303a30303a30305a')
-    assert impl.dumps(date(2013, 3, 21), timezone=timezone.utc) == expected
+    assert impl.dumps(date(2013, 3, 21), timezone=timezone.utc, date_as_datetime=True) == expected
 
 
 def test_naive_datetime(impl):


### PR DESCRIPTION
This branch fixes #37 but adds a flag to restore the old behavior. It may not be the most elegant solution, but it's the simplest one (that I know of).