### PR TITLE
setup: lower setuptools version requirement to 22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
         'local_scheme': 'dirty-tag'
     },
     setup_requires=[
-        'setuptools >= 36.2.7',
+        'setuptools >= 22.0.0',
         'setuptools_scm >= 1.7.0'
     ]
 )


### PR DESCRIPTION
This is needed for old packaging system like
Yocto Morty (2016) - in my case.

Signed-off-by: Patrick Boettcher <p@yai.se>