### PR TITLE
Include microseconds with timestamp encoding

### DIFF
--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -150,6 +150,7 @@ def encode_datetime(encoder, value):
             timestamp = timegm(value.utctimetuple())
         else:
             timestamp = timegm(value.utctimetuple()) + value.microsecond / 1000000
+
         encode_semantic(encoder, CBORTag(1, timestamp))
     else:
         datestring = as_unicode(value.isoformat().replace('+00:00', 'Z'))

--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import re
 import struct
 from collections import OrderedDict, defaultdict

--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -146,7 +146,10 @@ def encode_datetime(encoder, value):
 
     if encoder.datetime_as_timestamp:
         from calendar import timegm
-        timestamp = timegm(value.utctimetuple()) + value.microsecond // 1000000
+        if not value.microsecond:
+            timestamp = timegm(value.utctimetuple())
+        else:
+            timestamp = timegm(value.utctimetuple()) + value.microsecond / 1000000
         encode_semantic(encoder, CBORTag(1, timestamp))
     else:
         datestring = as_unicode(value.isoformat().replace('+00:00', 'Z'))

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -114,9 +114,10 @@ def test_simple_value(value, expected):
      'c07819323031332d30332d32315432323a30343a30302b30323a3030'),
     (datetime(2013, 3, 21, 20, 4, 0), False, 'c074323031332d30332d32315432303a30343a30305a'),
     (datetime(2013, 3, 21, 20, 4, 0, tzinfo=timezone.utc), True, 'c11a514b67b0'),
-    (datetime(2013, 3, 21, 22, 4, 0, tzinfo=timezone(timedelta(hours=2))), True, 'c11a514b67b0')
+    (datetime(2013, 3, 21, 20, 4, 0, 123456, tzinfo=timezone.utc), True, 'c1fb41d452d9ec07e6b4'),
+    (datetime(2013, 3, 21, 22, 4, 0, tzinfo=timezone(timedelta(hours=2))), True, 'c11a514b67b0'),
 ], ids=['datetime/utc', 'datetime+micro/utc', 'datetime/eet', 'naive', 'timestamp/utc',
-        'timestamp/eet'])
+        'timestamp+micro/utc', 'timestamp/eet'])
 def test_datetime(value, as_timestamp, expected):
     expected = unhexlify(expected)
     assert dumps(value, datetime_as_timestamp=as_timestamp, timezone=timezone.utc) == expected


### PR DESCRIPTION
Fixes #44 by using float division for microseconds in timestamp
encoding. Also maintains minimal representation (int) when microseconds
field is 0.