### PR TITLE
Reset shared reference after immutable conversion

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -80,9 +80,9 @@ def decode_array(decoder, subtype, shareable_index=None):
             items.append(item)
 
     if decoder.immutable:
-        return tuple(items)
-    else:
-        return items
+        items = tuple(items)
+        decoder.set_shareable(shareable_index, items)
+    return items
 
 
 def decode_map(decoder, subtype, shareable_index=None):
@@ -113,9 +113,10 @@ def decode_map(decoder, subtype, shareable_index=None):
 
     if decoder.object_hook:
         return decoder.object_hook(decoder, dictionary)
-    elif decoder.immutable:
-        return FrozenDict(dictionary)
     else:
+        if decoder.immutable:
+            dictionary = FrozenDict(dictionary)
+            decoder.set_shareable(shareable_index, dictionary)
         return dictionary
 
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -251,9 +251,9 @@ def test_uninitialized_shared_reference():
 
 
 def test_immutable_shared_reference():
-    #a = (1, 2, 3)
-    #b = ((a, a), a)
-    #data = dumps(set(b))
+    # a = (1, 2, 3)
+    # b = ((a, a), a)
+    # data = dumps(set(b))
     decoded = loads(unhexlify('d90102d81c82d81c82d81c83010203d81d02d81d02'))
     a = [item for item in decoded if len(item) == 3][0]
     b = [item for item in decoded if len(item) == 2][0]

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -250,6 +250,18 @@ def test_uninitialized_shared_reference():
     assert str(exc.value).endswith('shared value 0 has not been initialized')
 
 
+def test_immutable_shared_reference():
+    #a = (1, 2, 3)
+    #b = ((a, a), a)
+    #data = dumps(set(b))
+    decoded = loads(unhexlify('d90102d81c82d81c82d81c83010203d81d02d81d02'))
+    a = [item for item in decoded if len(item) == 3][0]
+    b = [item for item in decoded if len(item) == 2][0]
+    assert decoded == set(((a, a), a))
+    assert b[0] is a
+    assert b[1] is a
+
+
 def test_cyclic_array():
     decoded = loads(unhexlify('d81c81d81d00'))
     assert decoded == [decoded]


### PR DESCRIPTION
Fixes #46. When decoding immutable shared objects, reset the shared
reference after the conversion of the container to its immutable state
otherwise the container of the immutable item is likely to complain
about hashability.