### PR TITLE
Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,16 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+# Run CI for commits to the master branch, and PRs against the master branch;
+# other branches can be included or excluded here (see Concepts / Triggers in
+# Azure Pipelines docs for more details).
 
 trigger:
 - master
-- c_module
+
+pr:
+- master
+
+
+# Run CI against Linux, Mac OS X, and Windows, and a variety of Python
+# interpreters under each.
 
 strategy:
   matrix:
@@ -69,10 +74,18 @@ strategy:
     windows-py37-2019:
       python.version: '3.7'
       image.name: 'windows-2019'
-  maxParallel: 10
+  maxParallel: 10  # maximum for free usage
 
 pool:
   vmImage: $(image.name)
+
+
+# The following steps are executed in the order given. The UsePythonVersion
+# task sets up the Python interpreter with the specified version. Then pip and
+# pytest are used to install the package and execute tests. Finally, the
+# PublishTestResults task is used to publish the results to Azure. Coveralls
+# configuration should probably be added to the pytest script (or to a separate
+# one afterward).
 
 steps:
 - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,98 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+- c_module
+
+strategy:
+  matrix:
+    linux-py27:
+      python.version: '2.7'
+      image.name: 'ubuntu-16.04'
+    linux-py34:
+      python.version: '3.4'
+      image.name: 'ubuntu-16.04'
+    linux-py35:
+      python.version: '3.5'
+      image.name: 'ubuntu-16.04'
+    linux-py36:
+      python.version: '3.6'
+      image.name: 'ubuntu-16.04'
+    linux-py37:
+      python.version: '3.7'
+      image.name: 'ubuntu-16.04'
+    linux-pypy2:
+      python.version: 'pypy2'
+      image.name: 'ubuntu-16.04'
+    linux-pypy3:
+      python.version: 'pypy3'
+      image.name: 'ubuntu-16.04'
+    macos-py27:
+      python.version: '2.7'
+      image.name: 'macOS-10.14'
+    macos-py35:
+      python.version: '3.5'
+      image.name: 'macOS-10.14'
+    macos-py36:
+      python.version: '3.6'
+      image.name: 'macOS-10.14'
+    macos-py37:
+      python.version: '3.7'
+      image.name: 'macOS-10.14'
+    macos-pypy2:
+      python.version: 'pypy2'
+      image.name: 'macOS-10.14'
+    macos-pypy3:
+      python.version: 'pypy3'
+      image.name: 'macOS-10.14'
+    windows-py27-2017:
+      python.version: '2.7'
+      image.name: 'vs2017-win2016'
+    windows-py35-2017:
+      python.version: '3.5'
+      image.name: 'vs2017-win2016'
+    windows-py36-2017:
+      python.version: '3.6'
+      image.name: 'vs2017-win2016'
+    windows-py37-2017:
+      python.version: '3.7'
+      image.name: 'vs2017-win2016'
+    windows-py27-2019:
+      python.version: '2.7'
+      image.name: 'windows-2019'
+    windows-py36-2019:
+      python.version: '3.6'
+      image.name: 'windows-2019'
+    windows-py37-2019:
+      python.version: '3.7'
+      image.name: 'windows-2019'
+  maxParallel: 10
+
+pool:
+  vmImage: $(image.name)
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: $(python.version)
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install --upgrade setuptools pip wheel
+    pip install -e .[test]
+  displayName: 'Install dependencies'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest --junitxml=test-results.xml --cov-report=term
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFiles: '**/test-results.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
+  displayName: 'Publish test results'


### PR DESCRIPTION
Add a config for Azure Pipelines for CI. This tests the project under Linux, Mac OS X, and Windows (with VS2017 and VS2019), and a variety of interpreter versions.

**NOTE**: Coveralls config is *not* included; this should be added mostly like to the pytest script within the config, and neither is the flake8 config (mostly because I was more concerned with getting the other tests passing :). Deployment isn't included either - I'm not sure how that'd work under Pipelines - it seems to have its own systems for deployment but whether they apply to PyPI I don't know.