### PR TITLE
Fix compilation on macOS

### DIFF
--- a/source/decoder.h
+++ b/source/decoder.h
@@ -14,7 +14,7 @@ typedef struct {
     Py_ssize_t shared_index;
 } CBORDecoderObject;
 
-PyTypeObject CBORDecoderType;
+extern PyTypeObject CBORDecoderType;
 
 PyObject * CBORDecoder_new(PyTypeObject *, PyObject *, PyObject *);
 int CBORDecoder_init(CBORDecoderObject *, PyObject *, PyObject *);

--- a/source/encoder.h
+++ b/source/encoder.h
@@ -22,7 +22,7 @@ typedef struct {
     bool value_sharing;
 } CBOREncoderObject;
 
-PyTypeObject CBOREncoderType;
+extern PyTypeObject CBOREncoderType;
 
 PyObject * CBOREncoder_new(PyTypeObject *, PyObject *, PyObject *);
 int CBOREncoder_init(CBOREncoderObject *, PyObject *, PyObject *);

--- a/source/tags.h
+++ b/source/tags.h
@@ -8,7 +8,7 @@ typedef struct {
     PyObject *value;
 } CBORTagObject;
 
-PyTypeObject CBORTagType;
+extern PyTypeObject CBORTagType;
 
 PyObject * CBORTag_New(uint64_t);
 int CBORTag_SetValue(PyObject *, PyObject *);


### PR DESCRIPTION
In order to fix the compilation of cbor2 on macOS, the PyTypeObject variables where marked as `extern` in header files, thus resulting in being linked to the ones defined in the respective c files. 