### PR TITLE
Close #12

### DIFF
--- a/cbor2/__init__.py
+++ b/cbor2/__init__.py
@@ -3,7 +3,11 @@ from .encoder import dump, dumps, CBOREncoder, shareable_encoder  # noqa
 from .types import (  # noqa
     CBORError,
     CBOREncodeError,
+    CBOREncodeTypeError,
+    CBOREncodeValueError,
     CBORDecodeError,
+    CBORDecodeValueError,
+    CBORDecodeEOF,
     CBORTag,
     CBORSimpleValue,
     undefined

--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -14,7 +14,8 @@ from .compat import (
     iteritems, long, int2bytes, unicode, as_unicode, pack_float16,
     unpack_float16)
 from .types import (
-    CBOREncodeError, CBORTag, undefined, CBORSimpleValue, FrozenDict)
+    CBOREncodeTypeError, CBOREncodeValueError, CBORTag, undefined,
+    CBORSimpleValue, FrozenDict)
 
 
 def shareable_encoder(func):
@@ -99,7 +100,7 @@ class CBOREncoder(object):
                 try:
                     modname, typename = type_
                 except (TypeError, ValueError):
-                    raise CBOREncodeError(
+                    raise CBOREncodeValueError(
                         "invalid deferred encoder type {!r} (must be a "
                         "2-tuple of module name and type name, e.g. "
                         "('collections', 'defaultdict'))".format(type_))
@@ -191,7 +192,8 @@ class CBOREncoder(object):
             self._default
         )
         if not encoder:
-            raise CBOREncodeError('cannot serialize type %s' % obj_type.__name__)
+            raise CBOREncodeTypeError(
+                'cannot serialize type %s' % obj_type.__name__)
 
         encoder(self, obj)
 
@@ -235,7 +237,7 @@ class CBOREncoder(object):
                 self.encode_length(6, 0x1d)
                 self.encode_int(index)
             else:
-                raise CBOREncodeError(
+                raise CBOREncodeValueError(
                     'cyclic data structure detected but value sharing is '
                     'disabled')
 
@@ -328,7 +330,7 @@ class CBOREncoder(object):
             if self._timezone:
                 value = value.replace(tzinfo=self._timezone)
             else:
-                raise CBOREncodeError(
+                raise CBOREncodeValueError(
                     'naive datetime {!r} encountered and no default timezone '
                     'has been set'.format(value))
 

--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -2,16 +2,32 @@ from .compat import Mapping, recursive_repr
 from functools import total_ordering
 
 
-class CBORError(ValueError):
+class CBORError(Exception):
     "Base class for errors that occur during CBOR encoding or decoding."
 
 
 class CBOREncodeError(CBORError):
-    "Error class raised for exceptions occurring during CBOR encoding."
+    "Raised for exceptions occurring during CBOR encoding."
+
+
+class CBOREncodeTypeError(CBOREncodeError, TypeError):
+    "Raised when attempting to encode a type that cannot be serialized."
+
+
+class CBOREncodeValueError(CBOREncodeError, ValueError):
+    "Raised when the CBOR encoder encounters an invalid value."
 
 
 class CBORDecodeError(CBORError):
-    "Error class raised for exceptions occurring during CBOR decoding."
+    "Raised for exceptions occurring during CBOR decoding."
+
+
+class CBORDecodeValueError(CBORDecodeError, ValueError):
+    "Raised when the CBOR stream being decoded contains an invalid value."
+
+
+class CBORDecodeEOF(CBORDecodeError, EOFError):
+    "Raised when decoding unexpectedly reaches EOF."
 
 
 @total_ordering

--- a/source/encoder.c
+++ b/source/encoder.c
@@ -392,7 +392,7 @@ find_deferred(PyObject *type_tuple)
             return PyObject_GetAttr(mod, type_name);
         }
     }
-    PyErr_Format(_CBOR2_CBOREncodeError,
+    PyErr_Format(_CBOR2_CBOREncodeValueError,
             "invalid deferred encoder type %R (must be a 2-tuple of module "
             "name and type name, e.g. ('collections', 'defaultdict'))",
             type_tuple);
@@ -631,7 +631,7 @@ CBOREncoder_encode_bytearray(CBOREncoderObject *self, PyObject *value)
     Py_ssize_t length;
 
     if (!PyByteArray_Check(value)) {
-        PyErr_Format(_CBOR2_CBOREncodeError,
+        PyErr_Format(_CBOR2_CBOREncodeValueError,
                 "invalid bytearray value %R", value);
         return NULL;
     }
@@ -891,7 +891,7 @@ CBOREncoder_encode_datetime(CBOREncoderObject *self, PyObject *value)
                         self->tz,
                         PyDateTimeAPI->DateTimeType);
             } else {
-                PyErr_Format(_CBOR2_CBOREncodeError,
+                PyErr_Format(_CBOR2_CBOREncodeValueError,
                                 "naive datetime %R encountered and no default "
                                 "timezone has been set", value);
                 value = NULL;
@@ -1118,7 +1118,7 @@ encode_shared(CBOREncoderObject *self, EncodeFunction *encoder,
         } else {
             if (tuple) {
                 PyErr_SetString(
-                    _CBOR2_CBOREncodeError,
+                    _CBOR2_CBOREncodeValueError,
                     "cyclic data structure detected but value sharing is "
                     "disabled");
             } else {
@@ -1146,7 +1146,7 @@ shared_callback(CBOREncoderObject *self, PyObject *value)
                 self->shared_handler, self, value, NULL);
     } else {
         PyErr_Format(
-            _CBOR2_CBOREncodeError,
+            _CBOR2_CBOREncodeTypeError,
             "non-callable passed as shared encoding method");
         return NULL;
     }
@@ -1820,7 +1820,7 @@ encode(CBOREncoderObject *self, PyObject *value)
                             self->default_handler, self, value, NULL);
                 else
                     PyErr_Format(
-                        _CBOR2_CBOREncodeError,
+                        _CBOR2_CBOREncodeTypeError,
                         "cannot serialize type %R", (PyObject *)Py_TYPE(value));
                 Py_DECREF(encoder);
             }

--- a/source/module.h
+++ b/source/module.h
@@ -77,7 +77,11 @@ extern PyObject *_CBOR2_str_write;
 // Exception classes
 extern PyObject *_CBOR2_CBORError;
 extern PyObject *_CBOR2_CBOREncodeError;
+extern PyObject *_CBOR2_CBOREncodeTypeError;
+extern PyObject *_CBOR2_CBOREncodeValueError;
 extern PyObject *_CBOR2_CBORDecodeError;
+extern PyObject *_CBOR2_CBORDecodeValueError;
+extern PyObject *_CBOR2_CBORDecodeEOF;
 
 // Global references (initialized by functions declared below)
 extern PyObject *_CBOR2_timezone;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -144,6 +144,7 @@ def test_invalid_integer_subtype(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(b'\x1c')
         assert str(exc.value).endswith('unknown unsigned integer subtype 0x1c')
+        assert isinstance(exc, ValueError)
 
 
 @pytest.mark.parametrize('payload, expected', [
@@ -278,6 +279,7 @@ def test_bad_streaming_strings(impl, payload):
         impl.loads(unhexlify(payload))
         assert exc.match(
             r"non-(byte)?string found in indefinite length \1string")
+        assert isinstance(exc, ValueError)
 
 
 @pytest.fixture(params=[
@@ -322,6 +324,7 @@ def test_bad_datetime(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('c06b303030302d3132332d3031'))
         assert str(exc.value).endswith("invalid datetime string: '0000-123-01'")
+        assert isinstance(exc, ValueError)
 
 
 def test_fraction(impl):
@@ -380,10 +383,12 @@ def test_ipaddress(impl, payload, expected):
 def test_bad_ipaddress(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('d9010443c00a0a'))
-    assert str(exc.value).endswith('invalid ipaddress value %r' % b'\xc0\x0a\x0a')
+        assert str(exc.value).endswith('invalid ipaddress value %r' % b'\xc0\x0a\x0a')
+        assert isinstance(exc, ValueError)
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('d9010401'))
-    assert str(exc.value).endswith('invalid ipaddress value 1')
+        assert str(exc.value).endswith('invalid ipaddress value 1')
+        assert isinstance(exc, ValueError)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="Network decoding requires Py3.5+")
@@ -409,20 +414,23 @@ def test_ipnetwork(impl, payload, expected):
 def test_bad_ipnetwork(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('d90105a244c0a80064181844c0a800001818'))
-    assert str(exc.value).endswith(
-        'invalid ipnetwork value %r' %
-        {b'\xc0\xa8\x00d': 24, b'\xc0\xa8\x00\x00': 24})
+        assert str(exc.value).endswith(
+            'invalid ipnetwork value %r' %
+            {b'\xc0\xa8\x00d': 24, b'\xc0\xa8\x00\x00': 24})
+        assert isinstance(exc, ValueError)
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('d90105a144c0a80064420102'))
-    assert str(exc.value).endswith(
-        'invalid ipnetwork value %r' %
-        {b'\xc0\xa8\x00d': b'\x01\x02'})
+        assert str(exc.value).endswith(
+            'invalid ipnetwork value %r' %
+            {b'\xc0\xa8\x00d': b'\x01\x02'})
+        assert isinstance(exc, ValueError)
 
 
 def test_bad_shared_reference(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('d81d05'))
         assert str(exc.value).endswith('shared reference 5 not found')
+        assert isinstance(exc, ValueError)
 
 
 def test_uninitialized_shared_reference(impl):
@@ -432,6 +440,7 @@ def test_uninitialized_shared_reference(impl):
         # the expected error
         impl.loads(unhexlify('d90102d81c81d81d00'))
         assert str(exc.value).endswith('shared value 0 has not been initialized')
+        assert isinstance(exc, ValueError)
 
 
 def test_immutable_shared_reference(impl):
@@ -474,6 +483,7 @@ def test_premature_end_of_stream(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify('437879'))
         exc.match(r'premature end of stream \(expected to read 3 bytes, got 2 instead\)')
+        assert isinstance(exc, EOFError)
 
 
 def test_tag_hook(impl):
@@ -528,6 +538,7 @@ def test_nested_exception(impl):
             r"(unhashable type: '(_?cbor2\.)?CBORTag'"
             r"|"
             r"'(_?cbor2\.)?CBORTag' objects are unhashable)")
+        assert isinstance(exc, TypeError)
 
 
 def test_set(impl):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -239,8 +239,9 @@ def test_datetime(impl, value, as_timestamp, expected):
 def test_date_fails(impl, tz):
     encoder = impl.CBOREncoder(BytesIO(b''), timezone=tz, date_as_datetime=False)
     assert date not in encoder._encoders
-    with pytest.raises(impl.CBOREncodeError):
+    with pytest.raises(impl.CBOREncodeError) as exc:
         encoder.encode(date(2013, 3, 21))
+        assert isinstance(exc, ValueError)
 
 
 def test_date_as_datetime(impl):
@@ -254,6 +255,7 @@ def test_naive_datetime(impl):
         impl.dumps(datetime(2013, 3, 21))
         exc.match('naive datetime datetime.datetime(2013, 3, 21) encountered '
                   'and no default timezone has been set')
+        assert isinstance(exc, ValueError)
 
 
 @pytest.mark.parametrize('value, expected', [
@@ -339,6 +341,7 @@ def test_cyclic_array_nosharing(impl):
     with pytest.raises(impl.CBOREncodeError) as exc:
         impl.dumps(a)
         exc.match('cyclic data structure detected but value sharing is disabled')
+        assert isinstance(exc, ValueError)
 
 
 def test_cyclic_map(impl):
@@ -356,6 +359,7 @@ def test_cyclic_map_nosharing(impl):
     with pytest.raises(impl.CBOREncodeError) as exc:
         impl.dumps(a)
         exc.match('cyclic data structure detected but value sharing is disabled')
+        assert isinstance(exc, ValueError)
 
 
 @pytest.mark.parametrize('value_sharing, expected', [
@@ -374,6 +378,7 @@ def test_unsupported_type(impl):
     with pytest.raises(impl.CBOREncodeError) as exc:
         impl.dumps(lambda: None)
         exc.match('cannot serialize type function')
+        assert isinstance(exc, TypeError)
 
 
 def test_default(impl):


### PR DESCRIPTION
Use multiple inheritance to ensure there's still a library-specific root exception, but that exceptions raised by the codec also descend from "typical" Python exceptions like `ValueError` and `TypeError`.

Technically, this is a backwards incompatible change, because I've altered the root exception (`CBORError`) to descend from `Exception` rather than `ValueError`. However, excepting two cases, all exceptions raised encoding and decoding continue to descend from `ValueError`, but now via `CBOREncodeValueError` or `CBORDecodeValueError` rather than `CBORError`.

The two other cases are `CBORDecodeEOF` which now descends from `EOFError` (previously it descended from `ValueError` via `CBORError`), and `CBOREncodeTypeError` for non-serializable types. These are backwards incompatible changes but hopefully they're sufficiently minimal (and sane) that they don't cause any problems.

Incidentally if people think this is going too far, I'm happy to revise the PR to revert the base-class change - just thought I'd present an "idealized" situation first and see if it's sufficiently compatible to keep people happy!