### PR TITLE
Fix build for older gcc defaults and glibc/musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,9 @@ jobs:
 
 install: pip install tox
 
-script: tox -vv
+script:
+  - python -c "from __future__ import print_function; import platform; print(platform.libc_ver())"
+  - tox -vv
 
 after_success:
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
 
 install: pip install tox
 
-script: tox
+script: tox -vv
 
 after_success:
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,18 @@ import platform
 from setuptools import setup, Extension
 
 cpython = platform.python_implementation() == 'CPython'
+is_glibc = platform.libc_ver()[0] == 'glibc'
+libc_ok = is_glibc and platform.libc_ver()[1] >= '2.9'
 windows = sys.platform.startswith('win')
 min_win_version = windows and sys.version_info >= (3, 5)
 min_unix_version = not windows and sys.version_info >= (3, 3)
 
-if cpython and (min_unix_version or min_win_version):
+if cpython and ((min_unix_version and libc_ok) or min_win_version):
     _cbor2 = Extension(
         '_cbor2',
         # math.h routines are built-in to MSVCRT
         libraries=['m'] if not windows else [],
+        extra_compile_args=['-std=c99'],
         sources=[
             'source/module.c',
             'source/encoder.c',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ from setuptools import setup, Extension
 
 cpython = platform.python_implementation() == 'CPython'
 is_glibc = platform.libc_ver()[0] == 'glibc'
+windows = sys.platform.startswith('win')
 if is_glibc:
     glibc_ver = platform.libc_ver()[1]
     libc_ok = parse_version(glibc_ver) >= parse_version('2.9')
 else:
     libc_ok = not windows
-windows = sys.platform.startswith('win')
 min_win_version = windows and sys.version_info >= (3, 5)
 min_unix_version = not windows and sys.version_info >= (3, 3)
 

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,32 @@
 import sys
 import platform
+from pkg_resources import parse_version
 from setuptools import setup, Extension
 
 cpython = platform.python_implementation() == 'CPython'
 is_glibc = platform.libc_ver()[0] == 'glibc'
 if is_glibc:
     glibc_ver = platform.libc_ver()[1]
-    libc_numeric = tuple(int(x) for x in glibc_ver.split('.') if x.isdigit())
-    libc_ok = libc_numeric >= (2, 9)
+    libc_ok = parse_version(glibc_ver) >= parse_version('2.9')
 else:
-    libc_ok = False
+    libc_ok = not windows
 windows = sys.platform.startswith('win')
 min_win_version = windows and sys.version_info >= (3, 5)
 min_unix_version = not windows and sys.version_info >= (3, 3)
+
+# Enable GNU features for libc's like musl, should have no effect
+# on Apple/BSDs
+if libc_ok:
+    gnu_flag = ['-D_GNU_SOURCE']
+else:
+    gnu_flag = []
 
 if cpython and ((min_unix_version and libc_ok) or min_win_version):
     _cbor2 = Extension(
         '_cbor2',
         # math.h routines are built-in to MSVCRT
         libraries=['m'] if not windows else [],
-        extra_compile_args=['-std=c99'],
+        extra_compile_args=['-std=c99'] + gnu_flag,
         sources=[
             'source/module.c',
             'source/encoder.c',
@@ -43,4 +50,4 @@ setup(
         'setuptools_scm >= 1.7.0'
     ],
     **kwargs
-)
+    )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@ from setuptools import setup, Extension
 
 cpython = platform.python_implementation() == 'CPython'
 is_glibc = platform.libc_ver()[0] == 'glibc'
-libc_ok = is_glibc and platform.libc_ver()[1] >= '2.9'
+if is_glibc:
+    glibc_ver = platform.libc_ver()[1]
+    libc_numeric = tuple(int(x) for x in glibc_ver.split('.') if x.isdigit())
+    libc_ok = libc_numeric >= (2, 9)
+else:
+    libc_ok = False
 windows = sys.platform.startswith('win')
 min_win_version = windows and sys.version_info >= (3, 5)
 min_unix_version = not windows and sys.version_info >= (3, 3)

--- a/source/halffloat.c
+++ b/source/halffloat.c
@@ -5,7 +5,7 @@
 #include <sys/endian.h>
 #elif __APPLE__
 #include <libkern/OSByteOrder.h>
-#elif ! _WIN32
+#elif _GNU_SOURCE
 #include <endian.h>
 #endif
 #include "halffloat.h"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,19 @@ import cbor2.types
 import cbor2.encoder
 import cbor2.decoder
 
+load_exc = ''
 try:
     import _cbor2
-except ImportError:
+except ImportError as e:
+    if not str(e).startswith('No module'):
+        load_exc = str(e)
     _cbor2 = None
 
 cpython33 = pytest.mark.skipif(
     platform.python_implementation() != "CPython"
     or sys.version_info < (3, 3)
     or _cbor2 is None,
-    reason="requires CPython 3.3+ and glibc 2.9+",
+    reason=(load_exc or "requires CPython 3.3+"),
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,18 @@ import pytest
 import cbor2.types
 import cbor2.encoder
 import cbor2.decoder
+
 try:
     import _cbor2
 except ImportError:
     _cbor2 = None
 
-
 cpython33 = pytest.mark.skipif(
-    platform.python_implementation() != 'CPython' or sys.version_info < (3, 3),
-    reason="requires CPython 3.3+")
+    platform.python_implementation() != "CPython"
+    or sys.version_info < (3, 3)
+    or _cbor2 is None,
+    reason="requires CPython 3.3+ and glibc 2.9+",
+)
 
 
 class Module(object):
@@ -22,12 +25,9 @@ class Module(object):
     pass
 
 
-@pytest.fixture(params=[
-    pytest.param('c', marks=cpython33),
-    'python'
-], scope='session')
+@pytest.fixture(params=[pytest.param("c", marks=cpython33), "python"], scope="session")
 def impl(request):
-    if request.param == 'c':
+    if request.param == "c":
         return _cbor2
     else:
         # Make a mock module of cbor2 which always contains the pure Python


### PR DESCRIPTION
This is in response to #67 

The issue is caused by the `_cbor2` c-library using `-std=c99` but some versions of gcc default to c89.

Also in versions of glibc older than 2.9 and some versions of musl libc (not sure which ones yet) some of the 16 bit byteswap functions are missing from `endian.h`

Building the C library is temporarily disabled until these functions can be swapped out with their POSIX equivalents.