### PR TITLE
Fix deprecation warning

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -1,6 +1,6 @@
 import re
 import struct
-from collections import Mapping
+from .compat import Mapping
 from datetime import datetime, timedelta
 from io import BytesIO
 


### PR DESCRIPTION
This fixes the following warning:

.venv/lib/python3.7/site-packages/cbor2/decoder.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping