### PR TITLE
Fix C module on big-endian problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ jobs:
 
     - stage: test
       env: TOXENV=pypy
-      python: pypy2.7-6.0
+      python: pypy2.7-7.2.0
 
     - stage: test
       env: TOXENV=pypy3
-      python: pypy3.5-6.0
+      python: pypy3.5-7.2.0
 
     - stage: test
       env: TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
 
     - stage: test
       env: TOXENV=pypy3
-      python: pypy3.5-7.2.0
+      python: pypy3.6-7.2.0
 
     - stage: test
       env: TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python: "3.6"
 
@@ -41,6 +41,11 @@ jobs:
     - stage: test
       env: TOXENV=py38
       python: "3.8"
+      
+    - stage: test
+      env: TOXENV=py38
+      python: "3.8"
+      arch: s390x
 
     - stage: deploy to pypi
       install: true

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'local_scheme': 'dirty-tag'
     },
     setup_requires=[
-        'setuptools >= 36.2.7',
+        'setuptools >= 40.7.0',
         'setuptools_scm >= 1.7.0'
     ],
     **kwargs

--- a/source/halffloat.c
+++ b/source/halffloat.c
@@ -1,3 +1,4 @@
+#include <Python.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <math.h>
@@ -448,8 +449,13 @@ float unpack_float16(uint16_t i) {
     // equivalent value (handling infinity and NaN cases accordingly)
     union {
         struct {
+#if PY_BIG_ENDIAN
+            unsigned int exp: 6; // yes, this includes the sign
+            unsigned int sig: 10;
+#else
             unsigned int sig: 10;
             unsigned int exp: 6; // yes, this includes the sign
+#endif
         };
         uint16_t value;
     } in;
@@ -470,8 +476,13 @@ uint16_t pack_float16(float f) {
     // NaN cases accordingly); overflow returns infinity, underflow returns 0.0
     union {
         struct {
+#if PY_BIG_ENDIAN
+            unsigned int exp: 9;
+            unsigned int sig: 23;
+#else
             unsigned int sig: 23;
             unsigned int exp: 9; // again, this includes the sign
+#endif
         };
         float f;
     } in;

--- a/source/module.h
+++ b/source/module.h
@@ -9,7 +9,7 @@
 typedef
     union {
         struct {
-#if __BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
             unsigned int major: 3;
             unsigned int subtype: 5;
 #else

--- a/source/module.h
+++ b/source/module.h
@@ -9,7 +9,7 @@
 typedef
     union {
         struct {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if PY_BIG_ENDIAN
             unsigned int major: 3;
             unsigned int subtype: 5;
 #else

--- a/source/module.h
+++ b/source/module.h
@@ -1,7 +1,6 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#if PY_MAJOR_VERSION < 3
-#error "_cbor2 doesn't support the Python 2.x API"
-#elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 3
+#if PY_VERSION_HEX < 0x03030000
 #error "_cbor2 requires Python 3.3 or newer"
 #endif
 

--- a/source/module.h
+++ b/source/module.h
@@ -1,7 +1,7 @@
 #include <Python.h>
 #if PY_MAJOR_VERSION < 3
 #error "_cbor2 doesn't support the Python 2.x API"
-#elif PY_MAJOR_VERSION == 3 && PY_MAJOR_VERSION < 3
+#elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 3
 #error "_cbor2 requires Python 3.3 or newer"
 #endif
 

--- a/source/module.h
+++ b/source/module.h
@@ -9,8 +9,13 @@
 typedef
     union {
         struct {
+#if __BIG_ENDIAN
+            unsigned int major: 3;
+            unsigned int subtype: 5;
+#else
             unsigned int subtype: 5;
             unsigned int major: 3;
+#endif
         };
         char byte;
     } LeadByte;


### PR DESCRIPTION
Fix #75:
* Fix for endian problems with the `LeadByte` struct field ordering
* Fix for half-float encode/decode on big-endian
* Fix for argument unpacking booleans as ints on big-endian

Tested on s390x and MIPS32

Also workaround #74
(and make sure that setuptools supports utf-8 in setup.cfg, and detect python versions a bit better.)