### PR TITLE
Add optional flag to setuptools extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ if cpython and ((min_unix_version and libc_ok) or min_win_version):
             'source/decoder.c',
             'source/tags.c',
             'source/halffloat.c',
-        ]
+        ],
+        optional=True
     )
     kwargs = {'ext_modules': [_cbor2]}
 else:


### PR DESCRIPTION
This should prevent the whole install from failing in the event compilation fails. Especially helpful for when trying to install on Windows where Visual Studio isn't installed.

See [setuptools documentation](https://docs.python.org/3/distutils/apiref.html#distutils.core.Extension) for details.