### PR TITLE
Include 'load' and 'dump' in import in example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,7 +3,7 @@ Basic usage
 
 Serializing and deserializing with cbor2 is pretty straightforward::
 
-    from cbor2 import dumps, loads
+    from cbor2 import dump, dumps, load, loads
 
     # Serialize an object as a bytestring
     data = dumps(['hello', 'world'])


### PR DESCRIPTION
In the basic usage example it isn't explicitly clear that 'load' and 'dump' methods are available via the cbor2 module.

Very minor but it might help someone in the future.