### PR TITLE
Fix for #88 glibc version detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,42 @@
 import sys
+import os
 import platform
 from pkg_resources import parse_version
 from setuptools import setup, Extension
 
+min_glibc = parse_version('2.9')
+
+
+def check_libc():
+    "check that if we have glibc < 2.9 we should not build c ext"
+    # Borrowed from pip internals
+    # https://github.com/pypa/pip/blob/20.1.1/src/pip/_internal/utils/glibc.py#L21-L36
+    try:
+        # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17":
+        libc, version = os.confstr("CS_GNU_LIBC_VERSION").split()
+    except (AttributeError, OSError, ValueError):
+        # os.confstr() or CS_GNU_LIBC_VERSION not available (or a bad value)...
+        return True
+    if libc != 'glibc':
+        # Attempt to build with musl or other libc
+        return True
+    return parse_version(version) >= min_glibc
+
+
 cpython = platform.python_implementation() == 'CPython'
-is_glibc = platform.libc_ver()[0] == 'glibc'
 windows = sys.platform.startswith('win')
-if is_glibc:
-    glibc_ver = platform.libc_ver()[1]
-    libc_ok = parse_version(glibc_ver) >= parse_version('2.9')
-else:
-    libc_ok = not windows
-min_win_version = windows and sys.version_info >= (3, 5)
-min_unix_version = not windows and sys.version_info >= (3, 3)
+min_win_version = sys.version_info >= (3, 5)
+min_unix_version = sys.version_info >= (3, 3)
+build_c_ext = cpython and ((windows and min_win_version) or (check_libc() and min_unix_version))
 
 # Enable GNU features for libc's like musl, should have no effect
 # on Apple/BSDs
-if libc_ok:
+if build_c_ext and not windows:
     gnu_flag = ['-D_GNU_SOURCE']
 else:
     gnu_flag = []
 
-if cpython and ((min_unix_version and libc_ok) or min_win_version):
+if build_c_ext:
     _cbor2 = Extension(
         '_cbor2',
         # math.h routines are built-in to MSVCRT


### PR DESCRIPTION
Basically only refuse to build c ext if libc is GNU libc and it's less than 2.9