### PR TITLE
Allow overriding c extension build autodetection with env variable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,6 @@ wraps the ``_pickle`` C module in the Python Standard Library. On Windows, this 
 On PyPy, cbor2 runs with almost identical performance to the C backend.
 
 .. _RFC 7049: https://tools.ietf.org/html/rfc7049
+
+To force building of the optional C-extension, set OS env ``CBOR2_BUILD_C_EXTENSION=1``.
+To disable building of the optional C-extension, set OS env ``CBOR2_BUILD_C_EXTENSION=0``.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,13 @@ cpython = platform.python_implementation() == 'CPython'
 windows = sys.platform.startswith('win')
 min_win_version = sys.version_info >= (3, 5)
 min_unix_version = sys.version_info >= (3, 3)
-build_c_ext = cpython and ((windows and min_win_version) or (check_libc() and min_unix_version))
+use_c_ext = os.environ.get("CBOR2_BUILD_C_EXTENSION", None)
+if use_c_ext == "1":
+    build_c_ext = True
+elif use_c_ext == "0":
+    build_c_ext = False
+else:
+    build_c_ext = cpython and ((windows and min_win_version) or (check_libc() and min_unix_version))
 
 # Enable GNU features for libc's like musl, should have no effect
 # on Apple/BSDs


### PR DESCRIPTION
Similar to #87 but allows full overriding of the default behavior, useful in certain scenarios where auto-detection may be unreliable such as cross compilation.