### PR TITLE
Fix #93 segfault on allocating huge arrays

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -276,11 +276,11 @@ class CBORDecoder(object):
                 else:
                     items.append(value)
         else:
-            items = [None] * length
+            items = []
             if not self._immutable:
                 self.set_shareable(items)
             for index in range(length):
-                items[index] = self._decode()
+                items.append(self._decode())
 
         if self._immutable:
             items = tuple(items)
@@ -300,15 +300,6 @@ class CBORDecoder(object):
                     break
                 else:
                     dictionary[key] = self._decode(unshared=True)
-        elif self._share_index is None:
-            # Optimization: pre-allocate structures from length. Note this
-            # cannot be done when sharing the structure as the resulting
-            # structure is not the one initially allocated
-            seq = [None] * length
-            for index in range(length):
-                key = self._decode(immutable=True, unshared=True)
-                seq[index] = (key, self._decode(unshared=True))
-            dictionary = dict(seq)
         else:
             dictionary = {}
             self.set_shareable(dictionary)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -501,10 +501,7 @@ def test_bad_shared_reference(impl):
 
 def test_uninitialized_shared_reference(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
-        # encode a set of a recursive array; the set forces the embedded array
-        # to be decoded as a recursive tuple which is impossible, and leads to
-        # the expected error
-        impl.loads(unhexlify('d90102d81c81d81d00'))
+        impl.loads(unhexlify('D81CA1D81D014161'))
         assert str(exc.value).endswith('shared value 0 has not been initialized')
         assert isinstance(exc, ValueError)
 
@@ -626,3 +623,18 @@ def test_set(impl):
 def test_immutable_keys(impl, payload, expected):
     value = impl.loads(unhexlify(payload))
     assert value == expected
+
+
+def test_huge_truncated_array(impl):
+    with pytest.raises(impl.CBORDecodeEOF):
+        impl.loads(unhexlify('9b37388519251ae9ca'))
+
+
+def test_huge_truncated_bytes(impl):
+    with pytest.raises((impl.CBORDecodeEOF, MemoryError)):
+        impl.loads(unhexlify('5b37388519251ae9ca'))
+
+
+def test_huge_truncated_string(impl):
+    with pytest.raises((impl.CBORDecodeEOF, MemoryError)):
+        impl.loads(unhexlify('7B37388519251ae9ca'))


### PR DESCRIPTION
This removes some premature optimisations where we always pre-allocate an array no matter how huge it is.

I've done some performance tests and it makes decoding arrays only marginally faster.

So arrays and maps are all now created incrementally. Truncated data that has a huge length, will not try to grab all the memory in one go and will simply raise an exception on the first failed read.

I did leave in the pre-allocation for small arrays in the C module since that was easy and probably the most common case.