### PR TITLE
Fix for float equality in encode_minimal_float

### DIFF
--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -435,7 +435,7 @@ class CBOREncoder(object):
                 try:
                     new_encoded = struct.pack(format, tag, value)
                     # Check if encoding as low-byte float loses precision
-                    if struct.unpack(format, new_encoded)[1] == value:
+                    if math.isclose(struct.unpack(format, new_encoded)[1], value, rel_tol=0.0000001):
                         encoded = new_encoded
                     else:
                         break


### PR DESCRIPTION
Hello, I found a small bug in the `encode_minimal_float` function in `encoder.py`.  There is a line there that uses == to compare two floats which due to the nature of floats will basically always fail.  The result of this is that the function only returns 64bit encoded floats and never 32 bit or 16 bit ones.  It can be tested using the following code:

`from cbor2 import dumps

print(list(dumps(31.4, canonical=True)))`

To fix this, I did testing on the struct.pack and struct.unpack functionality to determine what error is inherent in these functions and floats themselves.  I found that for struct.pack/struct.unpack with a format of '>Bf' (a 32 bit float) there was an inherent relative error of approximately ~0.00000006 for all ranges of floats which is why I recommend a relative tolerance of 0.0000001.

One problem is that when I did testing on struct.pack and struct.unpack for a format of '>Be' (a 16 bit float), I found there was actually a relative error as high as ~0.2.  Maybe these two cases should be handled separately, but I am at least offering a solution for 32 bit floats.

Another part of this is that line 445 has the same problem: `if new_encoded and unpack_float16(new_encoded[1:]) == value:`.  However I did not pursue this problem as it appears that this only relates to python versions before 3.6 (I am using python 3.7). 

Thanks for the great work on this library, just want to help improve it!