### PR TITLE
Fixes for #116 and #118 Decimals losing precision and SystemErrors

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -427,7 +427,8 @@ class CBORDecoder:
         # Semantic tag 4
         from decimal import Decimal
         exp, sig = self._decode()
-        return self.set_shareable(Decimal(sig) * (10 ** Decimal(exp)))
+        tmp = Decimal(sig).as_tuple()
+        return self.set_shareable(Decimal((tmp.sign, tmp.digits, exp)))
 
     def decode_bigfloat(self):
         # Semantic tag 5

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -369,7 +369,11 @@ class CBORDecoder:
             return CBORSimpleValue(subtype)
 
         # Major tag 7
-        return special_decoders[subtype](self)
+        try:
+            return special_decoders[subtype](self)
+        except KeyError as e:
+            raise CBORDecodeValueError(
+                    "Undefined Reserved major type 7 subtype 0x%x" % subtype) from e
 
     #
     # Semantic decoders (major tag 6)

--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -430,14 +430,20 @@ class CBORDecoder:
     def decode_fraction(self):
         # Semantic tag 4
         from decimal import Decimal
-        exp, sig = self._decode()
+        try:
+            exp, sig = self._decode()
+        except (TypeError, ValueError) as e:
+            raise CBORDecodeValueError("Incorrect tag 4 payload") from e
         tmp = Decimal(sig).as_tuple()
         return self.set_shareable(Decimal((tmp.sign, tmp.digits, exp)))
 
     def decode_bigfloat(self):
         # Semantic tag 5
         from decimal import Decimal
-        exp, sig = self._decode()
+        try:
+            exp, sig = self._decode()
+        except (TypeError, ValueError) as e:
+            raise CBORDecodeValueError("Incorrect tag 5 payload") from e
         return self.set_shareable(Decimal(sig) * (2 ** Decimal(exp)))
 
     def decode_stringref(self):

--- a/source/decoder.c
+++ b/source/decoder.c
@@ -1606,7 +1606,9 @@ decode_special(CBORDecoderObject *self, uint8_t subtype)
             case 27: return CBORDecoder_decode_float64(self);
             case 31: CBOR2_RETURN_BREAK;
             default:
-                // XXX Raise exception?
+                PyErr_Format(
+                    _CBOR2_CBORDecodeValueError,
+                    "Undefined Reserved major type 7 subtype 0x%x", subtype);
                 break;
         }
     }

--- a/source/decoder.c
+++ b/source/decoder.c
@@ -1214,7 +1214,11 @@ CBORDecoder_decode_fraction(CBORDecoderObject *self)
                 }
                 Py_DECREF(tmp);
             }
-        }
+        } else {
+            PyErr_Format(
+                _CBOR2_CBORDecodeValueError,
+                            "Incorrect tag 4 payload");
+            }
         Py_DECREF(payload_t);
     }
     set_shareable(self, ret);
@@ -1246,7 +1250,11 @@ CBORDecoder_decode_bigfloat(CBORDecoderObject *self)
                 }
                 Py_DECREF(two);
             }
-        }
+        } else {
+            PyErr_Format(
+                _CBOR2_CBORDecodeValueError,
+                            "Incorrect tag 5 payload");
+            }
         Py_DECREF(tuple);
     }
     set_shareable(self, ret);

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -697,3 +697,13 @@ def test_invalid_cbor(impl):
             '4c271579b01633a3ef6271be5c225eb2'
             )
         )
+
+
+@pytest.mark.parametrize('data, expected', [
+    ('fc', '1c'), ('fd', '1d'), ('fe', '1e')
+    ],
+)
+def test_reserved_special_tags(impl, data, expected):
+    with pytest.raises(impl.CBORDecodeValueError) as exc_info:
+        impl.loads(unhexlify(data))
+    assert exc_info.value.args[0] == "Undefined Reserved major type 7 subtype 0x" + expected

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -707,3 +707,13 @@ def test_reserved_special_tags(impl, data, expected):
     with pytest.raises(impl.CBORDecodeValueError) as exc_info:
         impl.loads(unhexlify(data))
     assert exc_info.value.args[0] == "Undefined Reserved major type 7 subtype 0x" + expected
+
+
+@pytest.mark.parametrize('data, expected', [
+    ('c400', '4'), ('c500', '5')
+    ],
+)
+def test_decimal_payload_unpacking(impl, data, expected):
+    with pytest.raises(impl.CBORDecodeValueError) as exc_info:
+        impl.loads(unhexlify(data))
+    assert exc_info.value.args[0] == f"Incorrect tag {expected} payload"

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -384,6 +384,11 @@ def test_fraction(impl):
     assert decoded == Decimal('273.15')
 
 
+def test_decimal_precision(impl):
+    decoded = impl.loads(unhexlify('c482384dc252011f1fe37d0c70ff50456ba8b891997b07d6'))
+    assert decoded == Decimal('9.7703426561852468194804075821069770622934E-38')
+
+
 def test_bigfloat(impl):
     decoded = impl.loads(unhexlify('c5822003'))
     assert decoded == Decimal('1.5')


### PR DESCRIPTION
Solution: Instead of construct the Decimal arithmetically, build an
intermediate Decimal containing the sign and digits, then build the
final result with a tuple of `(sign, digits, exponent)`. Since there is no
calculation going on, the default precision in the Decimal context does
not take effect.

Unfortunately this does not work with bigfloat because the exponent in
that case is a power of 2 instead of a power of 10.

During the course of discovering and fixing this bug I found 2 instances of SystemError
Generated by the C-module caused by failing to set an error when failing
to return a result.