### PR TITLE
Bumped up the Python requirement to 3.7+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
-requires-python = ">= 3.6"
+requires-python = ">= 3.7"
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
My previous PR missed the change to bump the minimum Python requirement to 3.7. This also removes the 3.6 classifier.

When this is merged, you can force-add the 5.4.3 tag and force-push it to GitHub. That will trigger the publish process anew.