### PR TITLE
Add changelog link to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">= 3.7"
 dynamic = ["version"]
 
 [project.urls]
+Changelog = "https://cbor2.readthedocs.io/en/latest/versionhistory.html"
 Documentation = "https://cbor2.readthedocs.org/en/latest/"
 "Source Code" = "https://github.com/agronholm/cbor2"
 "Issue Tracker" = "https://github.com/agronholm/cbor2/issues"


### PR DESCRIPTION
This surfaces the changelog a bit more, in a "standard" place. PyPI will render a custom icon for 'Changelog', e.g. https://pypi.org/project/apig-wsgi/ .