### PR TITLE
decoder.py: Raise CBORDecodeValueError on invalid bignum values

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -454,6 +454,8 @@ class CBORDecoder:
         from binascii import hexlify
 
         value = self._decode()
+        if not isinstance(value, bytes):
+            raise CBORDecodeValueError("invalid bignum value " + str(value))
         return self.set_shareable(int(hexlify(value), 16))
 
     def decode_negative_bignum(self):


### PR DESCRIPTION
This matches the behavior of the C code. Code that expects a CBORDecodeValueError on invalid data will fail without this patch when running without the C extension, since the current code raises a ValueError.

I discovered this when I installed cbor2 on Python 3.11.0rc1, since it installed cbor2 without C extensions.