### PR TITLE
Make CBORTag hashable

### DIFF
--- a/cbor2/types.py
+++ b/cbor2/types.py
@@ -63,6 +63,9 @@ class CBORTag:
     def __repr__(self):
         return "CBORTag({self.tag}, {self.value!r})".format(self=self)
 
+    def __hash__(self):
+        return hash((self.tag, self.value))
+
 
 class CBORSimpleValue(namedtuple("CBORSimpleValue", ["value"])):
     """

--- a/source/tags.c
+++ b/source/tags.c
@@ -142,7 +142,7 @@ CBORTag_richcompare(PyObject *aobj, PyObject *bobj, int op)
 static Py_hash_t
 CBORTag_hash(CBORTagObject *self)
 {
-    PyObject *tmp = PyTuple_Pack(2, self->tag, self->value);
+    PyObject *tmp = Py_BuildValue("(iO)", self->tag, self->value);
     Py_hash_t ret = PyObject_Hash(tmp);
     return ret;
 }

--- a/source/tags.c
+++ b/source/tags.c
@@ -139,6 +139,15 @@ CBORTag_richcompare(PyObject *aobj, PyObject *bobj, int op)
 }
 
 
+static Py_hash_t
+CBORTag_hash(CBORTagObject *self)
+{
+    PyObject *tmp = PyTuple_Pack(2, self->tag, self->value);
+    Py_hash_t ret = PyObject_Hash(tmp);
+    return ret;
+}
+
+
 // C API /////////////////////////////////////////////////////////////////////
 
 PyObject *
@@ -205,5 +214,6 @@ PyTypeObject CBORTagType = {
     .tp_clear = (inquiry) CBORTag_clear,
     .tp_members = CBORTag_members,
     .tp_repr = (reprfunc) CBORTag_repr,
+    .tp_hash = (hashfunc) CBORTag_hash,
     .tp_richcompare = CBORTag_richcompare,
 };

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -701,7 +701,7 @@ def test_load_from_file(impl, tmpdir):
 def test_nested_dict(impl):
     value = impl.loads(unhexlify("A1D9177082010201"))
     assert type(value) is dict
-    assert value == {impl.CBORTag(6000, (1,2)): 1}
+    assert value == {impl.CBORTag(6000, (1, 2)): 1}
 
 
 def test_set(impl):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -698,15 +698,10 @@ def test_load_from_file(impl, tmpdir):
     assert obj == [1, 10]
 
 
-def test_nested_exception(impl):
-    with pytest.raises((impl.CBORDecodeError, TypeError)) as exc:
-        impl.loads(unhexlify("A1D9177082010201"))
-        exc.match(
-            r"(unhashable type: '(_?cbor2\.)?CBORTag'"
-            r"|"
-            r"'(_?cbor2\.)?CBORTag' objects are unhashable)"
-        )
-        assert isinstance(exc, TypeError)
+def test_nested_dict(impl):
+    value = impl.loads(unhexlify("A1D9177082010201"))
+    assert type(value) is dict
+    assert value == {impl.CBORTag(6000, (1,2)): 1}
 
 
 def test_set(impl):


### PR DESCRIPTION
This is a trivial solution to #147 by making the CBORTag hashable.