### PR TITLE
Updated GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish packages to PyPI
 
 on:
   push:
-    branches: [update-actions]
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+.post[0-9]+"
@@ -65,8 +64,7 @@ jobs:
       run: |
         mkdir dist
         mv */*.whl */*.tar.gz dist
-        tree
-#    - name: Upload packages
-#      uses: pypa/gh-action-pypi-publish@release/v1
-#      with:
-#        password: ${{ secrets.pypi_password }}
+    - name: Upload packages
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish packages to PyPI
 
 on:
   push:
+    branches: [update-actions]
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+.post[0-9]+"
@@ -18,17 +19,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: publish-${{ matrix.os }}
     - name: Set up QEMU
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.1
+      uses: pypa/cibuildwheel@v2.11.2
       env:
         CIBW_SKIP: pp*
         CIBW_ARCHS: auto64
@@ -39,7 +36,7 @@ jobs:
         name: wheels
         path: wheelhouse/*.whl
 
-  sdist:
+  sdist-purewheel:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -49,27 +46,29 @@ jobs:
         python-version: 3.x
     - name: Install dependencies
       run: pip install build
-    - name: Create sdist
-      run: python -m build --sdist .
+    - name: Create sdist and pure-Python wheel
+      run: python -m build .
+      env:
+        CBOR2_BUILD_C_EXTENSION: "0"
     - uses: actions/upload-artifact@v3
       with:
         name: sdist
-        path: dist/*.tar.gz
+        path: dist/*
 
   publish:
     needs:
       - wheels
-      - sdist
+      - sdist-purewheel
     runs-on: ubuntu-latest
     steps:
     - name: Download generated packaging artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Move the packages to dist/
       run: |
         mkdir dist
         mv */*.whl */*.tar.gz dist
-    - name: Upload packages
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+        tree
+#    - name: Upload packages
+#      uses: pypa/gh-action-pypi-publish@release/v1
+#      with:
+#        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
 
 jobs:
-  wheels:
+  binary-wheels:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -55,7 +55,7 @@ jobs:
 
   publish:
     needs:
-      - wheels
+      - binary-wheels
       - sdist-purewheel
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
     - name: Set up QEMU
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-test-${{ matrix.python-version }}-${{ matrix.os }}
+        cache: pip
+        cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: pip install -e .[test] coveralls
     - name: Test with pytest


### PR DESCRIPTION
* Publish a pure-Python wheel
* Updated the cibuildwheel, gh-action-pypi-publish and download-artifact actions to their latest versions
* Fixed Python cache not being used on macOS and Windows
* Removed useless setup-python and cache steps in the binary wheel build job
* Removed redundant `user` option in the publish action

Closes #146.