### PR TITLE
Fix potential memory leak in cbortag hash function

### DIFF
--- a/scripts/ref_leak_test.py
+++ b/scripts/ref_leak_test.py
@@ -21,8 +21,6 @@ from fractions import Fraction
 
 import objgraph
 
-import cbor2
-
 
 def import_cbor2():
     # Similar hack to that used in tests/conftest to get separate C and Python

--- a/scripts/ref_leak_test.py
+++ b/scripts/ref_leak_test.py
@@ -85,7 +85,7 @@ TEST_VALUES = [
         * 100,
     ),
     ("tag", {}, c_cbor2.CBORTag(1, 1)),
-    ("nestedtag", {}, {c_cbor2.CBORTag(1, 1) : 1}),
+    ("nestedtag", {}, {c_cbor2.CBORTag(1, 1): 1}),
 ]
 
 Leaks = namedtuple("Leaks", ("count", "comparison"))

--- a/scripts/ref_leak_test.py
+++ b/scripts/ref_leak_test.py
@@ -21,6 +21,8 @@ from fractions import Fraction
 
 import objgraph
 
+import cbor2
+
 
 def import_cbor2():
     # Similar hack to that used in tests/conftest to get separate C and Python
@@ -84,6 +86,8 @@ TEST_VALUES = [
         [{"name": "Foo", "species": "cat", "dob": datetime(2013, 5, 20), "weight": 4.1}]
         * 100,
     ),
+    ("tag", {}, c_cbor2.CBORTag(1, 1)),
+    ("nestedtag", {}, {c_cbor2.CBORTag(1, 1) : 1}),
 ]
 
 Leaks = namedtuple("Leaks", ("count", "comparison"))
@@ -237,7 +241,7 @@ def main():
     sys.stderr.write("Testing")
     sys.stderr.flush()
     for name, kwargs, value in TEST_VALUES:
-        encoded = py_cbor2.dumps(value, **kwargs)
+        encoded = c_cbor2.dumps(value, **kwargs)
         results[name] = Result(
             encoding=test(lambda: c_cbor2.dumps(value, **kwargs)),
             decoding=test(lambda: c_cbor2.loads(encoded)),

--- a/source/tags.c
+++ b/source/tags.c
@@ -144,6 +144,7 @@ CBORTag_hash(CBORTagObject *self)
 {
     PyObject *tmp = Py_BuildValue("(iO)", self->tag, self->value);
     Py_hash_t ret = PyObject_Hash(tmp);
+    Py_CLEAR(tmp);
     return ret;
 }
 

--- a/source/tags.c
+++ b/source/tags.c
@@ -109,7 +109,8 @@ CBORTag_richcompare(PyObject *aobj, PyObject *bobj, int op)
     } else {
         a = (CBORTagObject *)aobj;
         b = (CBORTagObject *)bobj;
-if (a == b) {
+
+        if (a == b) {
             // Special case: both are the same object
             switch (op) {
                 case Py_EQ: case Py_LE: case Py_GE: ret = Py_True; break;

--- a/source/tags.c
+++ b/source/tags.c
@@ -109,8 +109,7 @@ CBORTag_richcompare(PyObject *aobj, PyObject *bobj, int op)
     } else {
         a = (CBORTagObject *)aobj;
         b = (CBORTagObject *)bobj;
-
-        if (a == b) {
+if (a == b) {
             // Special case: both are the same object
             switch (op) {
                 case Py_EQ: case Py_LE: case Py_GE: ret = Py_True; break;
@@ -143,7 +142,12 @@ static Py_hash_t
 CBORTag_hash(CBORTagObject *self)
 {
     PyObject *tmp = Py_BuildValue("(iO)", self->tag, self->value);
+    if(!tmp){
+        PyErr_NoMemory();
+        return -1;
+    }
     Py_hash_t ret = PyObject_Hash(tmp);
+    Py_CLEAR(self->value);
     Py_CLEAR(tmp);
     return ret;
 }

--- a/source/tags.c
+++ b/source/tags.c
@@ -148,8 +148,7 @@ CBORTag_hash(CBORTagObject *self)
         return -1;
     }
     Py_hash_t ret = PyObject_Hash(tmp);
-    Py_CLEAR(self->value);
-    Py_CLEAR(tmp);
+    Py_DECREF(tmp);
     return ret;
 }
 


### PR DESCRIPTION
I fear I have introduced a memory leak with the implementation of the hash function. I have not been able to detect it properly, but digging through the documentation of the C-Python API gives that at least
- the reference count of the object passed into the tuple is increased by one when invoking Py_BuildValue
- probably the callee is in charge of handling the decrease of the reference count of the object created in Py_BuildValue

This also properly handles the case where the tuple allocation might fail.