### PR TITLE
Add Hypothesis encode/decode invariance test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_build/
 build/
 virtualenv/
 .vs
+.hypothesis

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Documentation = "https://cbor2.readthedocs.org/en/latest/"
 test = [
     "pytest",
     "pytest-cov",
+    "hypothesis",
 ]
 doc = [
     "sphinx_rtd_theme",

--- a/tests/hypothesis_strategies.py
+++ b/tests/hypothesis_strategies.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, defaultdict
+from datetime import timedelta, timezone
 
 from cbor2.types import FrozenDict
 from hypothesis import strategies
@@ -6,6 +7,12 @@ from hypothesis import strategies
 # Tune these for test run time
 MAX_SIZE = 5
 MAX_LEAVES = 2
+
+# Seconds in timezones get rounded when serialised, so we can only test whole minute
+# timezones for invariance
+timezones = strategies.integers(min_value=-(24 * 60 - 1), max_value=24 * 60 - 1).map(
+    lambda m: timezone(timedelta(minutes=m))
+)
 
 basic_immutable_strategy = strategies.one_of(
     strategies.none(),
@@ -16,8 +23,7 @@ basic_immutable_strategy = strategies.one_of(
     # nan != nan, so we can't test invariance with it
     strategies.floats(allow_nan=False),
     strategies.decimals(allow_nan=False),
-    # TODO: fix seconds in timezones
-    # strategies.datetimes(timezones=strategies.timezones()),
+    strategies.datetimes(timezones=timezones),
     # TODO: this needs to be fetched from impl fixture instead of imported
     # strategies.just(undefined),
     strategies.fractions(),

--- a/tests/hypothesis_strategies.py
+++ b/tests/hypothesis_strategies.py
@@ -67,4 +67,3 @@ compound_types_strategy = strategies.recursive(
     ),
     max_leaves=MAX_LEAVES,
 )
-# email.message

--- a/tests/hypothesis_strategies.py
+++ b/tests/hypothesis_strategies.py
@@ -1,0 +1,70 @@
+from collections import defaultdict, OrderedDict
+from cbor2.types import FrozenDict
+from hypothesis import strategies
+
+# Tune these for test run time
+MAX_SIZE = 5
+MAX_LEAVES = 2
+
+basic_immutable_strategy = strategies.one_of(
+    strategies.none(),
+    strategies.booleans(),
+    strategies.integers(),
+    strategies.binary(),
+    strategies.text(),
+    # nan != nan, so we can't test invariance with it
+    strategies.floats(allow_nan=False),
+    strategies.decimals(allow_nan=False),
+    # TODO: fix seconds in timezones
+    # strategies.datetimes(timezones=strategies.timezones()),
+    # TODO: this needs to be fetched from impl fixture instead of imported
+    # strategies.just(undefined),
+    strategies.fractions(),
+    strategies.uuids(),
+    strategies.ip_addresses(),
+    # TODO: regex objects for hypothesis
+    # MIMEText("foo") != MIMEText("foo"), so we cannot use it to test invariance
+    # strategies.text().map(MIMEText),
+)
+basic_types_strategy = strategies.one_of(
+    basic_immutable_strategy,
+    strategies.binary().map(bytearray),
+)
+
+@strategies.composite
+def arbitrary_length_tuple(draw, child_types):
+    i = draw(strategies.integers(min_value=0, max_value=MAX_SIZE))
+    return tuple(draw(child_types) for _ in range(i))
+
+dict_keys_strategy = strategies.one_of(
+    basic_immutable_strategy, arbitrary_length_tuple(basic_immutable_strategy)
+)
+
+compound_types_strategy = strategies.recursive(
+    strategies.one_of(
+        basic_types_strategy,
+        strategies.sets(basic_immutable_strategy, max_size=MAX_SIZE),
+        strategies.frozensets(basic_immutable_strategy, max_size=MAX_SIZE),
+    ),
+    lambda children: strategies.one_of(
+        strategies.lists(children, max_size=MAX_SIZE),
+        # lists and tuples encode to the same, so we can't test invariance with it.
+        # Dictionary keys, however, always need to encode to tuples since lists aren't
+        # immutable
+        strategies.dictionaries(dict_keys_strategy, children, max_size=MAX_SIZE),
+        strategies.dictionaries(
+            dict_keys_strategy,
+            children,
+            dict_class=lambda *a: defaultdict(None, *a),
+            max_size=MAX_SIZE
+        ),
+        strategies.dictionaries(
+            dict_keys_strategy, children, dict_class=OrderedDict, max_size=MAX_SIZE
+        ),
+        strategies.dictionaries(
+            dict_keys_strategy, children, dict_class=FrozenDict, max_size=MAX_SIZE
+        ),
+    ),
+    max_leaves=MAX_LEAVES,
+)
+# email.message

--- a/tests/hypothesis_strategies.py
+++ b/tests/hypothesis_strategies.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
+
 from cbor2.types import FrozenDict
 from hypothesis import strategies
 
@@ -31,10 +32,12 @@ basic_types_strategy = strategies.one_of(
     strategies.binary().map(bytearray),
 )
 
+
 @strategies.composite
 def arbitrary_length_tuple(draw, child_types):
     i = draw(strategies.integers(min_value=0, max_value=MAX_SIZE))
     return tuple(draw(child_types) for _ in range(i))
+
 
 dict_keys_strategy = strategies.one_of(
     basic_immutable_strategy, arbitrary_length_tuple(basic_immutable_strategy)
@@ -56,7 +59,7 @@ compound_types_strategy = strategies.recursive(
             dict_keys_strategy,
             children,
             dict_class=lambda *a: defaultdict(None, *a),
-            max_size=MAX_SIZE
+            max_size=MAX_SIZE,
         ),
         strategies.dictionaries(
             dict_keys_strategy, children, dict_class=OrderedDict, max_size=MAX_SIZE

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from email.mime.text import MIMEText
 from fractions import Fraction
+from hypothesis import given
 from io import BytesIO
 from ipaddress import ip_address, ip_network
 from uuid import UUID
@@ -12,6 +13,8 @@ from uuid import UUID
 import pytest
 from cbor2 import shareable_encoder
 from cbor2.types import FrozenDict
+
+from .hypothesis_strategies import compound_types_strategy
 
 
 def test_fp_attr(impl):
@@ -640,3 +643,12 @@ def test_invalid_tag(impl, tag):
 def test_largest_tag(impl):
     expected = unhexlify("dbffffffffffffffff6176")
     assert impl.dumps(impl.CBORTag(2**64 - 1, "v")) == expected
+
+
+@given(compound_types_strategy)
+def test_invariant_encode_decode(impl, val):
+    """
+    Tests that an encode and decode is invariant (the value is the same after
+    undergoing an encode and decode)
+    """
+    assert impl.loads(impl.dumps(val)) == val

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -5,7 +5,6 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from email.mime.text import MIMEText
 from fractions import Fraction
-from hypothesis import given
 from io import BytesIO
 from ipaddress import ip_address, ip_network
 from uuid import UUID
@@ -13,6 +12,7 @@ from uuid import UUID
 import pytest
 from cbor2 import shareable_encoder
 from cbor2.types import FrozenDict
+from hypothesis import given
 
 from .hypothesis_strategies import compound_types_strategy
 


### PR DESCRIPTION
This PR is resulting from the DjangoCon Europe Sprints

Adds a Hypothesis tests, that ensures that encoding and decoding is invariant, ie. if you encode an object, and then decode that result, you'll get the same object that you started off with.

There are some other TODOs, which are not trivial. I'm not sure if we want to require these to be done, or leave them out as they might not be worth the effort:
- Add `undefined`. The `undefined` type depends on which implementation we're using (C vs Python), and it doesn't seem trivial to select the correct one in the test
- Add regex data type. Hypothesis doesn't have a regex strategy, and it doesn't seem trivial to add one.
