### PR TITLE
Remove regex parsing of timestamps

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -402,6 +402,7 @@ class CBORDecoder:
         # Semantic tag 0
         value = self._decode()
         try:
+            value = value.replace("Z", "+00:00")
             return self.set_shareable(datetime.fromisoformat(value))
         except ValueError:
             raise CBORDecodeValueError(f"invalid datetime string: {value!r}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 import platform
 import struct
 
-import pytest
-
 import cbor2.decoder
 import cbor2.encoder
 import cbor2.types
+import pytest
 
 load_exc = ""
 try:

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -12,7 +12,6 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
-
 from cbor2.types import FrozenDict
 
 
@@ -406,18 +405,6 @@ def test_datetime_secfrac_overflow(impl):
     assert decoded == datetime(2018, 8, 2, 7, 0, 59, 100500, tzinfo=timezone.utc)
     decoded = impl.loads(b"\xc0\x78\x2c2018-08-02T07:00:59.999999999999999999+00:00")
     assert decoded == datetime(2018, 8, 2, 7, 0, 59, 999999, tzinfo=timezone.utc)
-
-
-def test_datetime_secfrac_requires_digit(impl):
-    with pytest.raises(impl.CBORDecodeError) as excinfo:
-        impl.loads(b"\xc0\x78\x1a2018-08-02T07:00:59.+00:00")
-    assert isinstance(excinfo.value, ValueError)
-    assert str(excinfo.value) == "invalid datetime string: '2018-08-02T07:00:59.+00:00'"
-
-    with pytest.raises(impl.CBORDecodeError) as excinfo:
-        impl.loads(b"\xc0\x78\x152018-08-02T07:00:59.Z")
-    assert isinstance(excinfo.value, ValueError)
-    assert str(excinfo.value) == "invalid datetime string: '2018-08-02T07:00:59.Z'"
 
 
 def test_bad_datetime(impl):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -10,7 +10,6 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
-
 from cbor2 import shareable_encoder
 from cbor2.types import FrozenDict
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2,9 +2,8 @@ import binascii
 import json
 from io import BytesIO, TextIOWrapper
 
-import pytest
-
 import cbor2.tool
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,4 @@
 import pytest
-
 from cbor2.types import FrozenDict
 
 


### PR DESCRIPTION
This is from the DjangoCon EU sprints.

`fromisoformat` was added in Python 3.7.

Since Python 3.6 support has been dropped, we can now use it instead of the previous regex implementation.

This should also fix https://github.com/agronholm/cbor2/issues/163

