### PR TITLE
Both hours and minutes of timezone should be affected by the timezone sign

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -426,13 +426,12 @@ class CBORDecoder:
                 microsecond = int(f"{secfrac:<06}")
 
             if offset_h:
-                hours = int(offset_h)
-                minutes = int(offset_m)
                 if offset_sign == "-":
-                    if hours:
-                        hours *= -1
-                    else:
-                        minutes *= -1
+                    sign = -1
+                else:
+                    sign = 1
+                hours = int(offset_h) * sign
+                minutes = int(offset_m) * sign
                 tz = timezone(timedelta(hours=hours, minutes=minutes))
             else:
                 tz = timezone.utc

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -435,6 +435,14 @@ def test_datetime_timezone(impl):
     assert decoded == datetime(
         2018, 8, 2, 7, 0, 59, tzinfo=timezone(timedelta(minutes=-30))
     )
+    decoded = impl.loads(b"\xc0\x78\x192018-08-02T07:00:59+01:30")
+    assert decoded == datetime(
+        2018, 8, 2, 7, 0, 59, tzinfo=timezone(timedelta(minutes=90))
+    )
+    decoded = impl.loads(b"\xc0\x78\x192018-08-02T07:00:59-01:30")
+    assert decoded == datetime(
+        2018, 8, 2, 7, 0, 59, tzinfo=timezone(timedelta(minutes=-90))
+    )
 
 
 def test_positive_bignum(impl):


### PR DESCRIPTION
This PR is from DjangoCon EU.

Previously, the sign and hour were linked, which meant that if the hour was zero, the sign was lost. This was fixed in https://github.com/agronholm/cbor2/issues/163

But, the minute should also be affected by the sign, since `timedelta(hours=-1, minutes=1) is `-0:59`, not `-1:01`.

This PR proposes a fix for this issue.
