### PR TITLE
Handle UnicodeDecodeError correctly.

### DIFF
--- a/cbor2/decoder.py
+++ b/cbor2/decoder.py
@@ -302,7 +302,12 @@ class CBORDecoder:
                         raise CBORDecodeValueError(
                             "invalid length for indefinite string chunk 0x%x" % length
                         )
-                    value = self.read(length).decode("utf-8", self._str_errors)
+                    try:
+                        value = self.read(length).decode("utf-8", self._str_errors)
+                    except UnicodeDecodeError as e:
+                        raise CBORDecodeValueError(
+                            "Invalid value for utf-8 string"
+                        ) from e
                     buf.append(value)
                 else:
                     raise CBORDecodeValueError(
@@ -311,7 +316,10 @@ class CBORDecoder:
         else:
             if length > sys.maxsize:
                 raise CBORDecodeValueError("invalid length for string 0x%x" % length)
-            result = self.read(length).decode("utf-8", self._str_errors)
+            try:
+                result = self.read(length).decode("utf-8", self._str_errors)
+            except UnicodeDecodeError as e:
+                raise CBORDecodeValueError("Invalid value for utf-8 string") from e
             self._stringref_namespace_add(result, length)
         return self.set_shareable(result)
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -12,6 +12,7 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
+
 from cbor2.types import FrozenDict
 
 
@@ -805,6 +806,11 @@ def test_invalid_cbor(impl):
                 "50db78974c271579b01633a3ef6271be5c225eb2"
             )
         )
+
+
+def test_invalid_utf8(impl):
+    with pytest.raises(impl.CBORDecodeError):
+        impl.loads(b"\x61\x98")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -12,7 +12,6 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
-
 from cbor2.types import FrozenDict
 
 


### PR DESCRIPTION
This wraps the unicode error in a `CBORDecodeValueError` since a string type that is not valid utf-8 is also not valid CBOR.

Fixes #156