### PR TITLE
Updated testing, packaging and docs configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    environment: release
     steps:
     - uses: actions/checkout@v3
     - name: Set up QEMU
@@ -35,6 +36,7 @@ jobs:
 
   sdist-purewheel:
     runs-on: ubuntu-latest
+    environment: release
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -57,6 +59,9 @@ jobs:
       - binary-wheels
       - sdist-purewheel
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - name: Download generated packaging artifacts
       uses: actions/download-artifact@v3
@@ -66,5 +71,3 @@ jobs:
         mv */*.whl */*.tar.gz dist
     - name: Upload packages
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,29 +10,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.8"]
-        exclude:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+        include:
         - os: macos-latest
-          python-version: "3.8"
+          python-version: "3.7"
         - os: macos-latest
-          python-version: "3.9"
-        - os: macos-latest
-          python-version: "3.10"
-        - os: macos-latest
-          python-version: "pypy-3.7"
-        - os: macos-latest
-          python-version: "pypy-3.8"
+          python-version: "3.11"
         - os: windows-latest
-          python-version: "3.8"
+          python-version: "3.7"
         - os: windows-latest
-          python-version: "3.9"
-        - os: windows-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "pypy-3.7"
-        - os: windows-latest
-          python-version: "pypy-3.8"
+          python-version: "3.11"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -40,6 +28,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
@@ -58,11 +47,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-    - name: Install dependencies
-      run: pip install coveralls
-    - name: Notify Coveralls
-      run: coveralls --service=github --finish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,15 @@
 version: 2
-formats: [htmlzip, pdf]
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
 python:
-   version: 3.7
    install:
       - method: pip
         path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-import pkg_resources
+from importlib.metadata import version as get_version
+
+from packaging.version import parse
 
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 
@@ -10,11 +12,11 @@ project = "cbor2"
 author = "Alex Grönholm"
 copyright = "2016, " + author
 
-v = pkg_resources.get_distribution(project).parsed_version
+v = parse(get_version("cbor2"))
 version = v.base_version
 release = v.public
 
-language = None
+language = "en"
 
 exclude_patterns = ["_build"]
 pygments_style = "sphinx"
@@ -25,4 +27,4 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 htmlhelp_basename = project.replace("-", "") + "doc"
 
-intersphinx_mapping = {"python": ("http://docs.python.org/", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/", None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,10 @@ from importlib.metadata import version as get_version
 
 from packaging.version import parse
 
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+]
 
 templates_path = ["_templates"]
 source_suffix = ".rst"
@@ -24,7 +27,6 @@ highlight_language = "python"
 todo_include_todos = False
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
 htmlhelp_basename = project.replace("-", "") + "doc"
 
 intersphinx_mapping = {"python": ("https://docs.python.org/", None)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 61",
+    "setuptools >= 64",
     "setuptools_scm[toml] >= 6.4"
 ]
 build-backend = "setuptools.build_meta"
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">= 3.7"
 dynamic = ["version"]
@@ -41,6 +42,7 @@ test = [
     "hypothesis",
 ]
 doc = [
+    "packaging",
     "sphinx_rtd_theme",
     "sphinx-autodoc-typehints >= 1.2.0",
 ]
@@ -74,7 +76,7 @@ show_missing = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37, py38, py39, py310, py311, pypy3
+envlist = py37, py38, py39, py310, py311, py312, pypy3
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
 ]
 doc = [
     "packaging",
+    "Sphinx < 7",
     "sphinx_rtd_theme",
     "sphinx-autodoc-typehints >= 1.2.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ else:
 
 setup(
     use_scm_version={"version_scheme": "guess-next-dev", "local_scheme": "dirty-tag"},
-    setup_requires=["setuptools >= 61", "setuptools_scm >= 6.4"],
+    setup_requires=["setuptools >= 64", "setuptools_scm >= 6.4"],
     **kwargs,
 )


### PR DESCRIPTION
* Simplifies testing matrix
* Declared Python 3.12 support and added it to the testing matrix
* Switched to trusted publishing for PyPI uploads
* Updated ReadTheDocs config to the latest format
* Fixed problems with `conf.py` and updated it to not use the deprecated `pkg_resources` package

I'm considering ditching the `sphinx-rtd-theme` package in my other projects, as it's continuously causing problems due to being far behind Sphinx itself in development. I've kept it in the config for now.