### PR TITLE
Switched from flake8+isort+pyupgrade to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,33 +15,13 @@ repos:
         args: [ "--fix=lf" ]
       - id: trailing-whitespace
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.277
     hooks:
-      - id: pyupgrade
-        args: [ "--py37-plus" ]
+      - id: ruff
+        args: [--fix, --show-fixes]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/csachs/pyproject-flake8
-    rev: v6.0.0.post1
-    hooks:
-      - id: pyproject-flake8
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
-      - id: python-no-eval
-      - id: rst-backticks
-      - id: rst-directive-colons
-      - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.0.278
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black

--- a/cbor2/__init__.py
+++ b/cbor2/__init__.py
@@ -14,7 +14,7 @@ from .types import (  # noqa: F401
 )
 
 try:
-    from _cbor2 import *  # noqa: F401,F403
+    from _cbor2 import *  # noqa: F403
 except ImportError:
     # Couldn't import the optimized C version; ignore the failure and leave the
     # pure Python implementations in place.
@@ -30,7 +30,7 @@ else:
         import _cbor2
 
         from .encoder import canonical_encoders, default_encoders
-        from .types import CBORSimpleValue, CBORTag, undefined  # noqa: F8
+        from .types import CBORSimpleValue, CBORTag, undefined  # noqa: F811
 
         _cbor2.default_encoders = OrderedDict(
             [

--- a/cbor2/encoder.py
+++ b/cbor2/encoder.py
@@ -329,7 +329,7 @@ class CBOREncoder:
                 self.encode_int(index)
             else:
                 raise CBOREncodeValueError(
-                    "cyclic data structure detected but value sharing is " "disabled"
+                    "cyclic data structure detected but value sharing is disabled"
                 )
 
     def _stringref(self, value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,16 @@ benchmarks = [
 [tool.setuptools.packages.find]
 include = ["cbor2"]
 
-[tool.isort]
-src_paths = ["src"]
-skip_gitignore = true
-profile = "black"
-
-[tool.flake8]
-max-line-length = 99
-exclude = ".tox,build,docs"
+[tool.ruff]
+line-length = 99
+select = [
+    "E", "F", "W",  # default flake-8
+    "I",            # isort
+    "ISC",          # flake8-implicit-str-concat
+    "PGH",          # pygrep-hooks
+    "RUF100",       # unused noqa (yesqa)
+    "UP",           # pyupgrade
+]
 
 [tool.pytest.ini_options]
 addopts = "-rsx --cov --tb=short"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import platform
 import struct
 
+import pytest
+
 import cbor2.decoder
 import cbor2.encoder
 import cbor2.types
-import pytest
 
 load_exc = ""
 try:

--- a/tests/hypothesis_strategies.py
+++ b/tests/hypothesis_strategies.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict, defaultdict
 from datetime import timedelta, timezone
 
-from cbor2.types import FrozenDict
 from hypothesis import strategies
+
+from cbor2.types import FrozenDict
 
 # Tune these for test run time
 MAX_SIZE = 5

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -12,6 +12,7 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
+
 from cbor2.types import FrozenDict
 
 
@@ -40,7 +41,7 @@ def test_tag_hook_attr(impl):
         decoder = impl.CBORDecoder(stream)
 
         def tag_hook(decoder, tag):
-            return None  # noqa: E731
+            return None
 
         decoder.tag_hook = tag_hook
         assert decoder.tag_hook is tag_hook
@@ -55,7 +56,7 @@ def test_object_hook_attr(impl):
         decoder = impl.CBORDecoder(stream)
 
         def object_hook(decoder, data):
-            return None  # noqa: E731
+            return None
 
         decoder.object_hook = object_hook
         assert decoder.object_hook is object_hook
@@ -526,7 +527,9 @@ def test_ipaddress(impl, payload, expected):
 def test_bad_ipaddress(impl):
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify("d9010443c00a0a"))
-        assert str(exc.value).endswith("invalid ipaddress value %r" % b"\xc0\x0a\x0a")
+        assert str(exc.value).endswith(
+            "invalid ipaddress value {!r}".format(b"\xc0\x0a\x0a")
+        )
         assert isinstance(exc, ValueError)
     with pytest.raises(impl.CBORDecodeError) as exc:
         impl.loads(unhexlify("d9010401"))

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -10,9 +10,10 @@ from ipaddress import ip_address, ip_network
 from uuid import UUID
 
 import pytest
+from hypothesis import given
+
 from cbor2 import shareable_encoder
 from cbor2.types import FrozenDict
-from hypothesis import given
 
 from .hypothesis_strategies import compound_types_strategy
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2,8 +2,9 @@ import binascii
 import json
 from io import BytesIO, TextIOWrapper
 
-import cbor2.tool
 import pytest
+
+import cbor2.tool
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cbor2.types import FrozenDict
 
 


### PR DESCRIPTION
This simplifies linting considerably. Ruff is not only a lot faster, but consolidates a lot of different tools into one, and is very actively maintained.