### PR TITLE
Use trusted publishing to publish packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    environment: release
     steps:
     - uses: actions/checkout@v3
     - name: Set up QEMU
@@ -35,6 +36,7 @@ jobs:
 
   sdist-purewheel:
     runs-on: ubuntu-latest
+    environment: release
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -57,6 +59,9 @@ jobs:
       - binary-wheels
       - sdist-purewheel
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - name: Download generated packaging artifacts
       uses: actions/download-artifact@v3
@@ -66,5 +71,3 @@ jobs:
         mv */*.whl */*.tar.gz dist
     - name: Upload packages
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This is the recommended practice nowadays.