### PR TITLE
Don't allow simple values between 24 and 31 (inclusive)

### DIFF
--- a/cbor2/_types.py
+++ b/cbor2/_types.py
@@ -90,8 +90,8 @@ class CBORSimpleValue(namedtuple("CBORSimpleValue", ["value"])):
         return hash(self.value)
 
     def __new__(cls, value: int) -> CBORSimpleValue:
-        if value < 0 or value > 255:
-            raise TypeError("simple value out of range (0..255)")
+        if value < 0 or value > 255 or 23 < value < 32:
+            raise TypeError("simple value out of range (0..23, 32..255)")
 
         return super().__new__(cls, value)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,11 @@ Version history
 
 This library adheres to `Semantic Versioning <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``CBORSimpleValue`` allowing the use of reserved values (24 to 31) which resulted in
+  invalid byte sequences
+
 **5.5.0** (2023-10-21)
 
 - The ``cbor2.encoder``, ``cbor2.decoder`` or ``cbor2.types`` modules were deprecated – import

--- a/source/module.c
+++ b/source/module.c
@@ -174,8 +174,8 @@ CBORSimpleValue_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n", keywords, &val))
         return NULL;
 
-    if (val < 0 || val > 255) {
-        PyErr_SetString(PyExc_TypeError, "simple value out of range (0..255)");
+    if (val < 0 || val > 255 || (val > 23 && val < 32)) {
+        PyErr_SetString(PyExc_TypeError, "simple value out of range (0..23, 32..255)");
         return NULL;
     }
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -120,10 +120,12 @@ def test_simple_ordering(impl):
     assert expected == sorted(randints)
 
 
-def test_simple_value_too_big(impl):
+@pytest.mark.parametrize("value", [-1, 24, 31, 256])
+def test_simple_value_out_of_range(impl, value):
     with pytest.raises(TypeError) as exc:
-        impl.CBORSimpleValue(256)
-        assert str(exc.value) == "simple value out of range (0..255)"
+        impl.CBORSimpleValue(value)
+
+    assert str(exc.value) == "simple value out of range (0..23, 32..255)"
 
 
 def test_frozendict():


### PR DESCRIPTION
These values have no valid encodings.

Fixes #187.