### PR TITLE
Add CIFuzz GitHub Action

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -42,7 +42,7 @@ jobs:
           path: ./out/artifacts
       - name: Upload Sarif
         if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,6 +1,7 @@
 name: CIFuzz
 
 on:
+  workflow_dispatch:
   pull_request:
     # Fuzzing is currently only targeting the C extension
     paths:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,7 @@ name: CIFuzz
 
 on:
   pull_request:
-    # Fuzzing is currently only targetting the C extension
+    # Fuzzing is currently only targeting the C extension
     paths:
       - "**.c"
       - "**.cc"
@@ -41,7 +41,7 @@ jobs:
           path: ./out/artifacts
       - name: Upload Sarif
         if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,48 @@
+name: CIFuzz
+
+on:
+  pull_request:
+    # Fuzzing is currently only targetting the C extension
+    paths:
+      - "**.c"
+      - "**.cc"
+      - "**.cpp"
+      - "**.cxx"
+      - "**.h"
+
+permissions: {}
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: "cbor2"
+          language: python
+          dry-run: true
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: "cbor2"
+          language: python
+          fuzz-seconds: 600
+          output-sarif: true
+          dry-run: true
+      - name: Upload Crash
+        uses: actions/upload-artifact@v3
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts
+      - name: Upload Sarif
+        if: always() && steps.build.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: cifuzz-sarif/results.sarif
+          checkout_path: cifuzz-sarif

--- a/source/module.c
+++ b/source/module.c
@@ -6,11 +6,6 @@
 #include "encoder.h"
 #include "decoder.h"
 
-/*
- * TODO: remove me before merging PR https://github.com/agronholm/cbor2/pull/212.
- * This comment exists to force a change to a .c file, which the Action requires to run.
- */
-
 
 // Some notes on conventions in this code. All methods conform to a couple of
 // return styles:

--- a/source/module.c
+++ b/source/module.c
@@ -6,6 +6,11 @@
 #include "encoder.h"
 #include "decoder.h"
 
+/*
+ * TODO: remove me before merging PR https://github.com/agronholm/cbor2/pull/212.
+ * This comment exists to force a change to a .c file, which the Action requires to run.
+ */
+
 
 // Some notes on conventions in this code. All methods conform to a couple of
 // return styles:


### PR DESCRIPTION
Now that `cbor2` has been integrated into OSS-Fuzz, I thought it would be helpful to run a short CIFuzz job on PRs. This Action is pretty much verbatim from the OSS-Fuzz CI docs here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/.