### PR TITLE
Move OSS-Fuzz target file under tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ doc = [
 benchmarks = [
     "pytest-benchmark==4.0.0",
 ]
+fuzz = [
+    "atheris",
+]
 
 [project.scripts]
 cbor2 = "cbor2.tool:main"

--- a/tests/fuzzers/loads_fuzzer.py
+++ b/tests/fuzzers/loads_fuzzer.py
@@ -1,0 +1,22 @@
+import sys
+import atheris
+
+# _cbor2 ensures the C library is imported
+from _cbor2 import loads
+
+
+def test_one_input(data: bytes):
+    try:
+        loads(data)
+    except Exception:
+        # We're searching for memory corruption, not Python exceptions
+        pass
+
+
+def main():
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi again!

I'm back working on fuzzing and trying to learn more about OSS-Fuzz. After my initial research into this project, I'm now hoping to promote it to OSS-Fuzz's ["initial integration"](https://bughunters.google.com/about/rules/5097259337383936/oss-fuzz-reward-program-rules#fuzzing-integration) tier. This requires: "Fuzz targets need to be checked into their upstream repository and integrated into the build system with sanitizer support."

I think this also helps with project developers who'd like to run the fuzz tests, but not necessarily install all the OSS-Fuzz infrastructure. `loads_fuzzer.py` can be run locally with the following commands...

First, install the `fuzz` dependencies:

```
python -m pip install -e .[fuzz]
```

Next, run the fuzz tests:

```
python tests/fuzzers/loads_fuzzer.py
```

This should produce output like the following:

```
INFO: Using preloaded libfuzzer
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2252594525
INFO: Loaded 1 modules   (4545 inline 8-bit counters): 4545 [0xffffb9d38c20, 0xffffb9d39de1), 
INFO: Loaded 1 PC tables (4545 PCs): 4545 [0xffffb9d39de8,0xffffb9d4b9f8), 
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED cov: 123 ft: 124 corp: 1/1b exec/s: 0 rss: 61Mb
	NEW_FUNC[1/1]: 0xffffb9cdb030 in decode_bytestring /app/cbor2/source/decoder.c:686
#5	NEW    cov: 132 ft: 141 corp: 2/2b lim: 4 exec/s: 0 rss: 62Mb L: 1/1 MS: 3 CrossOver-CopyPart-ChangeBit-
	NEW_FUNC[1/1]: 0xffffb9ce0ce8 in string_namespace_add /app/cbor2/source/decoder.c:512
...
```

Let me know if you'd like `loads_fuzzer.py` to live in a different location in the repository.