### PR TITLE
Drop support for EOL Python 3.8

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ these instructions.
 If there are no entries after the last release, use `**UNRELEASED**` as the version.
 If, say, your patch fixes issue #999, the entry should look like this:
 
-`* Fix big bad boo-boo in the encoder (#999
+`- Fixed big bad boo-boo in the encoder (#999
 <https://github.com/agronholm/cbor2/issues/999>_; PR by @yourgithubaccount)`
 
 If there's no issue linked, just link to your pull request instead by updating the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.21.3
       env:
         CBOR2_BUILD_C_EXTENSION: "1"
-        CIBW_SKIP: pp* cp36* cp37*
+        CIBW_SKIP: pp*
         CIBW_ARCHS: auto64
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_ARCHS_LINUX: x86_64 aarch64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
         include:
         - os: macos-latest
-          python-version: "3.8"
+          python-version: "3.9"
         - os: macos-latest
           python-version: "3.12"
         - os: windows-latest
-          python-version: "3.8"
+          python-version: "3.9"
         - os: windows-latest
           python-version: "3.12"
     runs-on: ${{ matrix.os }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.x"
 
 sphinx:
   configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Installation
 Requirements
 ------------
 
-* Python >= 3.8 (or `PyPy3`_ 3.8+)
+* Python >= 3.9 (or `PyPy3`_ 3.9+)
 * C-extension: Any C compiler that can build Python extensions.
   Any modern libc with the exception of Glibc<2.9
 

--- a/cbor2/_encoder.py
+++ b/cbor2/_encoder.py
@@ -257,7 +257,7 @@ class CBOREncoder:
         return self._canonical
 
     @contextmanager
-    def disable_value_sharing(self) -> Generator[None, None, None]:
+    def disable_value_sharing(self) -> Generator[None]:
         """
         Disable value sharing in the encoder for the duration of the context
         block.
@@ -268,7 +268,7 @@ class CBOREncoder:
         self.value_sharing = old_value_sharing
 
     @contextmanager
-    def disable_string_referencing(self) -> Generator[None, None, None]:
+    def disable_string_referencing(self) -> Generator[None]:
         """
         Disable tracking of string references for the duration of the
         context block.
@@ -279,7 +279,7 @@ class CBOREncoder:
         self.string_referencing = old_string_referencing
 
     @contextmanager
-    def disable_string_namespacing(self) -> Generator[None, None, None]:
+    def disable_string_namespacing(self) -> Generator[None]:
         """
         Disable generation of new string namespaces for the duration of the
         context block.

--- a/cbor2/_types.py
+++ b/cbor2/_types.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import threading
 from collections import namedtuple
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from functools import total_ordering
 from reprlib import recursive_repr
-from typing import Any, Mapping, TypeVar
+from typing import Any, TypeVar
 
 KT = TypeVar("KT")
 VT_co = TypeVar("VT_co", covariant=True)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,10 +5,10 @@ Version history
 
 This library adheres to `Semantic Versioning <https://semver.org/>`_.
 
-**UNRELEASED** (yyyy-mm-dd)
+**UNRELEASED**
 
-- Dropped support for Python 3.8 (#247
-  <https://github.com/agronholm/cbor2/pull/247>_; PR by @hugovk)
+- Dropped support for Python 3.8
+  (#247 <https://github.com/agronholm/cbor2/pull/247>_; PR by @hugovk)
 
 **5.6.5** (2024-10-09)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,7 +3,12 @@ Version history
 
 .. currentmodule:: cbor2
 
-This library adheres to `Semantic Versioning <http://semver.org/>`_.
+This library adheres to `Semantic Versioning <https://semver.org/>`_.
+
+**UNRELEASED** (yyyy-mm-dd)
+
+- Dropped support for Python 3.8 (#247
+  <https://github.com/agronholm/cbor2/pull/247>_; PR by @hugovk)
 
 **5.6.5** (2024-10-09)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dynamic = ["version"]
 
 [project.urls]
@@ -90,7 +89,7 @@ show_missing = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38, py39, py310, py311, py312, py313, pypy3
+envlist = py39, py310, py311, py312, py313, pypy3
 skip_missing_interpreters = true
 minversion = 4.0.0
 

--- a/source/decoder.c
+++ b/source/decoder.c
@@ -1254,12 +1254,7 @@ parse_datetimestr(CBORDecoderObject *self, PyObject *str)
                     (offset_sign ? -1 : 1) *
                     (offset_H * 3600 + offset_M * 60), 0);
                 if (delta) {
-#if PY_VERSION_HEX >= 0x03070000
                     tz = PyTimeZone_FromOffset(delta);
-#else
-                    tz = PyObject_CallFunctionObjArgs(
-                        _CBOR2_timezone, delta, NULL);
-#endif
                     Py_DECREF(delta);
                 }
             } else

--- a/source/module.c
+++ b/source/module.c
@@ -525,31 +525,10 @@ error:
 int
 _CBOR2_init_timezone_utc(void)
 {
-#if PY_VERSION_HEX >= 0x03070000
     Py_INCREF(PyDateTime_TimeZone_UTC);
     _CBOR2_timezone_utc = PyDateTime_TimeZone_UTC;
     _CBOR2_timezone = NULL;
     return 0;
-#else
-    PyObject* datetime;
-
-    // from datetime import timezone
-    // utc = timezone.utc
-    datetime = PyImport_ImportModule("datetime");
-    if (!datetime)
-        goto error;
-    _CBOR2_timezone = PyObject_GetAttr(datetime, _CBOR2_str_timezone);
-    Py_DECREF(datetime);
-    if (!_CBOR2_timezone)
-        goto error;
-    _CBOR2_timezone_utc = PyObject_GetAttr(_CBOR2_timezone, _CBOR2_str_utc);
-    if (!_CBOR2_timezone_utc)
-        goto error;
-    return 0;
-error:
-    PyErr_SetString(PyExc_ImportError, "unable to import timezone from datetime");
-    return -1;
-#endif
 }
 
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -13,7 +13,7 @@ from fractions import Fraction
 from io import BytesIO
 from ipaddress import ip_address, ip_network
 from pathlib import Path
-from typing import Type, cast
+from typing import cast
 from uuid import UUID
 
 import pytest
@@ -955,7 +955,7 @@ def test_decimal_payload_unpacking(impl, data, expected):
     ],
 )
 def test_oversized_read(impl, payload: bytes, tmp_path: Path) -> None:
-    CBORDecodeEOF = cast(Type[Exception], getattr(impl, "CBORDecodeEOF"))
+    CBORDecodeEOF = cast(type[Exception], getattr(impl, "CBORDecodeEOF"))
     with pytest.raises(CBORDecodeEOF, match="premature end of stream"):
         dummy_path = tmp_path / "testdata"
         dummy_path.write_bytes(payload)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Drop support for EOL Python 3.8.

Remove redundant code and upgrade syntax for 3.9+.

https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [n/a] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the encoder (#999
<https://github.com/agronholm/cbor2/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
