### PR TITLE
Fix str_errors parameter regression in C extension (#255)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``str_errors`` parameter being ignored in C extension when decoding strings with
+  invalid UTF-8 byte sequences (broken since 5.6.0)
+  (`#255 <https://github.com/agronholm/cbor2/issues/255>`_; PR by @topher200)
+
 **5.8.0** (2025-12-30)
 
 - Added readahead buffering to C decoder for improved performance.

--- a/source/decoder.c
+++ b/source/decoder.c
@@ -836,7 +836,7 @@ decode_definite_short_string(CBORDecoderObject *self, Py_ssize_t length)
         return NULL;
 
     const char *bytes = PyBytes_AS_STRING(bytes_obj);
-    PyObject *ret = PyUnicode_FromStringAndSize(bytes, length);
+    PyObject *ret = PyUnicode_DecodeUTF8(bytes, length, PyBytes_AS_STRING(self->str_errors));
     Py_DECREF(bytes_obj);
     if (ret && string_namespace_add(self, ret, length) == -1) {
         Py_DECREF(ret);
@@ -895,7 +895,7 @@ decode_definite_long_string(CBORDecoderObject *self, Py_ssize_t length)
         }
 
         consumed = chunk_length;  // workaround for https://github.com/python/cpython/issues/99612
-        string = PyUnicode_DecodeUTF8Stateful(source_buffer, chunk_length, NULL, &consumed);
+        string = PyUnicode_DecodeUTF8Stateful(source_buffer, chunk_length, PyBytes_AS_STRING(self->str_errors), &consumed);
         if (!string)
             goto error;
 


### PR DESCRIPTION
## Summary

Fixes #255 - Restores support for the `str_errors` parameter in the C extension when decoding CBOR strings containing invalid UTF-8 byte sequences. The parameter has been broken since v5.6.0.

## Problem Description

Since version 5.6.0, the `str_errors` parameter in `cbor2.loads()` stopped working in the C extension (`_cbor2`). When decoding CBOR data containing invalid UTF-8 sequences:

**Expected behavior (v5.5.1 and earlier):**
```python
cbor2.loads(b"cfo\x90", str_errors="replace")  # Returns: 'fo�'
```

**Broken behavior (v5.6.0 - v5.8.0):**
```python
cbor2.loads(b"cfo\x90", str_errors="replace")  # Raises: CBORDecodeValueError
```

The pure Python implementation (`cbor2._decoder`) continued to work correctly; only the C extension was affected.

## Root Cause

**Commit 387755e (PR #204) - "Fixed MemoryError when decoding large definite strings"** Date: Jan 14, 2024

This commit rewrote the string decoding logic in `source/decoder.c` to handle large strings in chunks, fixing memory issues. However, it accidentally removed the `str_errors` parameter from UTF-8 decoding calls:

**Before (v5.5.1 - working):**
```c
ret = PyUnicode_DecodeUTF8(buf, length, PyBytes_AS_STRING(self->str_errors));
```

**After (v5.6.0 - broken):**
```c
// Short strings (≤65536 bytes)
PyObject *ret = PyUnicode_FromStringAndSize(bytes, length);  // No error handler support

// Long strings (>65536 bytes)
string = PyUnicode_DecodeUTF8Stateful(source_buffer, chunk_length, NULL, &consumed);  // NULL instead of str_errors
```

### Changes

Re-add the missing parameter.

Fixes #255 

 ### Test Plan

Add a new unit test for this functionality.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
