### PR TITLE
Broadened decoder support to any type supporting the buffer interface

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,7 +10,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the ``allow_duplicate_keys`` parameter to :class:`CBORDecoder`, :func:`load` and
   :func:`loads` (default: ``True``). When set to ``False``, a :exc:`CBORDecodeError` is raised
   upon encountering a duplicate key within the same map.
-  (`#283 <https://github.com/agronholm/cbor2/pull/283>`_)
+  (`#283 <https://github.com/agronholm/cbor2/issues/283>`_)
+- Added support for decoding from any object supporting the buffer API (e.g. ``memoryview`` or
+  ``bytearray``) in addition to ``bytes``
+  (`#297 <https://github.com/agronholm/cbor2/issues/297>`_)
 
 **6.0.1** (2026-04-29)
 

--- a/python/cbor2/__init__.pyi
+++ b/python/cbor2/__init__.pyi
@@ -29,6 +29,11 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import TypeVar
 
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -219,7 +224,7 @@ def load(
     immutable: bool = ...,
 ) -> Any: ...
 def loads(
-    data: bytes,
+    data: Buffer,
     *,
     tag_hook: TagHook | None = ...,
     object_hook: ObjectHook | None = ...,

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -10,6 +10,8 @@ use pyo3::prelude::pymodule;
 /// A Python module implemented in Rust.
 #[pymodule]
 mod _cbor2 {
+    use pyo3::buffer::PyBuffer;
+    use pyo3::exceptions::PyTypeError;
     use pyo3::prelude::*;
     use pyo3::sync::PyOnceLock;
     use pyo3::types::{PyBytes, PyMapping};
@@ -142,7 +144,10 @@ mod _cbor2 {
     /// Deserialize an object from a bytestring.
     ///
     /// :param data:
-    ///     the bytestring to deserialize
+    ///     the bytestring (or any object implementing the buffer protocol) to deserialize
+    ///
+    ///     .. note:: Types other than :class:`bytes` will be converted to :class:`bytes`, involving
+    ///               memory copying.
     /// :param tag_hook:
     ///     callable that takes 2 arguments: the decoder instance, and the :class:`.CBORTag`
     ///     to be decoded. This callback is invoked for any tags for which there is no
@@ -189,7 +194,7 @@ mod _cbor2 {
     ))]
     fn loads<'py>(
         py: Python<'py>,
-        data: Bound<'py, PyBytes>,
+        data: &Bound<'py, PyAny>,
         tag_hook: Option<&Bound<'py, PyAny>>,
         object_hook: Option<&Bound<'py, PyAny>>,
         semantic_decoders: Option<&Bound<'py, PyMapping>>,
@@ -199,10 +204,23 @@ mod _cbor2 {
         allow_duplicate_keys: bool,
         immutable: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let bytes = if let Ok(bytes) = data.cast::<PyBytes>() {
+            bytes.clone()
+        } else if let Ok(pybuf) = PyBuffer::<u8>::get(data) {
+            PyBytes::new_with(py, pybuf.item_count(), |target| {
+                pybuf.copy_to_slice(py, target)
+            })?
+        } else {
+            return Err(PyTypeError::new_err(format!(
+                "a bytes-like object is required, not '{}'",
+                data.get_type().qualname()?
+            )));
+        };
+
         let mut decoder = CBORDecoder::new_internal(
             py,
             None,
-            Some(data),
+            Some(bytes),
             tag_hook,
             object_hook,
             semantic_decoders,

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1356,3 +1356,16 @@ def test_override_semantic_decoder() -> None:
 
     payload = unhexlify("c11a514b67b0")  # datetime(2013, 3, 21, 20, 4, 0, tzinfo=timezone.utc)
     assert loads(payload, semantic_decoders={1: date_decoder}) == datetime(2026, 2, 18)
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        pytest.param(bytes, id="bytes"),
+        pytest.param(bytearray, id="bytearray"),
+        pytest.param(memoryview, id="memoryview"),
+    ],
+)
+def test_loads_buffer_input(input_type: type) -> None:
+    payload = unhexlify("82010a")
+    assert loads(input_type(payload)) == [1, 10]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Broadens input type support to all objects implementing the buffer protocol.

Closes #297.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in the encoder
  (`#123 <https://github.com/agronholm/cbor2/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
