### PR TITLE
Fixed read_exact() truncating buffer incorrectly

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``cbor2.load()`` crash caused by incorrect handling
+  of internal read buffer extension during stream deserialization.
+  (`#307 <https://github.com/agronholm/cbor2/pull/307>`_; PR by @noderyos)
+
 **6.1.1** (2026-05-14)
 
 - Fixed ``cbor2.load()`` returning corrupted data for payloads exceeding 4096 bytes

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -288,7 +288,7 @@ impl CBORDecoder {
             if self.read_position > 0 {
                 concatenated_buffer.drain(..self.read_position);
             }
-            concatenated_buffer.truncate(needed_bytes);
+            concatenated_buffer.truncate(self.available_bytes);
             let (new_bytes, amount_read) = self.read_from_fp(py, needed_bytes)?;
             concatenated_buffer.extend_from_slice(&new_bytes[..needed_bytes]);
             self.buffer = Some(new_bytes.unbind());

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1383,3 +1383,15 @@ def test_load_exceeds_buffer_size(data: object) -> None:
     payload = dumps(data)
     buf = BytesIO(payload)
     assert load(buf) == data
+
+
+def test_load_buffer_truncation() -> None:
+    """
+    With read_size=4096, load() will request more bytes than are currently
+    available in the internal buffer (requesting 8 bytes while only 6 remain),
+    triggering buffer truncation/extension.
+    """
+    data = [3.14] * 455
+    payload = dumps(data)
+    buf = BytesIO(payload)
+    assert load(buf, read_size=4096) == data


### PR DESCRIPTION
## Changes

New code added in 985d54c introduced a bug.

Currently, in `read_exact`, when `self.available_bytes < N`, `needed_bytes` is set at `N - self.available_bytes`.
`concatenated_buffer` is then truncated to `needed_bytes` and extended with `new_bytes` of length `needed_bytes`.

However, to match the final expected length of `N`, `concatenated_buffer` should be truncated to `self.available_bytes`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in the encoder
  (`#123 <https://github.com/agronholm/cbor2/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.