### PR TITLE
fix incorrect length tracking for chunked text strings

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed incorrect tracking of string references for definite-length text strings of length greater
+  than 65536
+  (`#308 <https://github.com/agronholm/cbor2/pull/308>`_; PR by @sahvx655-wq)
+
 **6.1.1** (2026-05-14)
 
 - Fixed ``cbor2.load()`` returning corrupted data for payloads exceeding 4096 bytes

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -490,7 +490,7 @@ impl CBORDecoder {
                 };
                 Ok(StringValue(decoded_string, length))
             }
-            Some(mut length) => {
+            Some(length) => {
                 // Incrementally decode the string, in chunks of 65536 bytes
                 let decoder_class = INCREMENTAL_UTF8_DECODER
                     .get_or_try_init(py, || -> PyResult<Py<PyAny>> {
@@ -507,11 +507,12 @@ impl CBORDecoder {
                     Some(str_errors) => decoder_class.call1((str_errors,))?,
                 };
                 let mut string = PyString::new(py, "").into_any();
-                while length > 0 {
-                    let chunk_size = length.min(65536);
+                let mut remaining_length = length;
+                while remaining_length > 0 {
+                    let chunk_size = remaining_length.min(65536);
                     let chunk = self.read(py, chunk_size)?;
-                    length -= chunk_size;
-                    let is_final_chunk = length == 0;
+                    remaining_length -= chunk_size;
+                    let is_final_chunk = remaining_length == 0;
                     let decoded_chunk =
                         decoder.call_method1(intern!(py, "decode"), (chunk, is_final_chunk))?;
                     string = string.add(decoded_chunk)?;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -963,6 +963,19 @@ class TestStringReference:
         with pytest.raises(CBORDecodeError, match="string reference 3 not found$"):
             loads(unhexlify("d9010086656669727374d81900667365636f6e64d81900d81901d81903"))
 
+    def test_string_ref_long_text_string(self) -> None:
+        """Regression test for #308."""
+        big_string = "a" * 65537
+        payload = (
+            b"\xd9\x01\x00"  # tag 256 (string namespace)
+            b"\x82"  # array of 2
+            b"\x7a"
+            + struct.pack(">I", 65537)  # text string, 4-byte length
+            + big_string.encode("ascii")  # 65537 bytes of 'a'
+            + b"\xd8\x19\x00"  # tag 25, value 0 (string reference to index 0)
+        )
+        assert loads(payload) == [big_string, big_string]
+
 
 @pytest.mark.parametrize(
     "payload, expected",


### PR DESCRIPTION
decode_string reuses the `length` variable as the chunk loop counter and decrements it to 0 before returning it, so any definite-length text string over 65536 bytes reports a length of 0. That length feeds the string-reference namespace eligibility check (tag 256), so a long string is never registered, misaligning later string-reference indices and decoding valid CBOR to the wrong string or raising "string reference not found". The bytestring path already tracks the remaining length separately; mirror that here.