### PR TITLE
Add array_hook to surface indefinite-length arrays on decode

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,15 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added the ``array_hook`` parameter to :class:`CBORDecoder`, :func:`load` and :func:`loads`.
+  When set, it is called for each decoded array with two arguments: the array (a :class:`list`,
+  or a :class:`tuple` when ``immutable`` is true) and a boolean indicating whether the array used
+  indefinite-length encoding. Its return value is substituted for the array in the output. This
+  allows callers to preserve the distinction between definite- and indefinite-length arrays, which
+  is otherwise lost after decoding.
+
 **6.1.2** (2026-06-02)
 
 - Fixed incorrect tracking of string references for definite-length text strings of length greater

--- a/python/cbor2/__init__.pyi
+++ b/python/cbor2/__init__.pyi
@@ -48,6 +48,7 @@ _TContainer = TypeVar("_TContainer", default=None)
 TagHook: TypeAlias = Callable[[CBORTag, bool], Any]
 SemanticDecoderCallback: TypeAlias = Callable[[Any, bool], Any]
 ObjectHook: TypeAlias = Callable[[Mapping[Any, Any], bool], Any]
+ArrayHook: TypeAlias = Callable[[Sequence[Any], bool], Any]
 EncoderHook: TypeAlias = Callable[[CBOREncoder, Any], Any]
 ShareableDecoderCallback: TypeAlias = Callable[[Any], Any]
 ShareableDecoderInitializer: TypeAlias = Callable[[bool], tuple[Any, ShareableDecoderCallback]]
@@ -117,6 +118,7 @@ class CBORDecoder:
     fp: IO[bytes]
     tag_hook: TagHook | None
     object_hook: ObjectHook | None
+    array_hook: ArrayHook | None
     str_errors: str
     def __new__(
         cls,
@@ -124,6 +126,7 @@ class CBORDecoder:
         *,
         tag_hook: TagHook | None = ...,
         object_hook: ObjectHook | None = ...,
+        array_hook: ArrayHook | None = ...,
         semantic_decoders: Mapping[int, SemanticDecoderCallback | ShareableDecoderInitializer]
         | None = ...,
         str_errors: str = ...,
@@ -214,6 +217,7 @@ def load(
     *,
     tag_hook: TagHook | None = ...,
     object_hook: ObjectHook | None = ...,
+    array_hook: ArrayHook | None = ...,
     semantic_decoders: Mapping[int, SemanticDecoderCallback | ShareableDecoderInitializer]
     | None = ...,
     str_errors: str = ...,
@@ -228,6 +232,7 @@ def loads(
     *,
     tag_hook: TagHook | None = ...,
     object_hook: ObjectHook | None = ...,
+    array_hook: ArrayHook | None = ...,
     semantic_decoders: Mapping[int, SemanticDecoderCallback | ShareableDecoderInitializer]
     | None = ...,
     str_errors: str = ...,

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -158,6 +158,13 @@ fn require_tuple<'py>(value: Bound<'py, PyAny>, length: usize) -> PyResult<Bound
 ///     callable that takes 2 arguments: the decoder instance, and a dictionary. This
 ///     callback is invoked for each deserialized :class:`dict` object. The return value
 ///     is substituted for the dict in the deserialized output.
+/// :param array_hook:
+///     callable that takes 2 arguments: the decoded array (a :class:`list`, or a
+///     :class:`tuple` when ``immutable`` is true), and a boolean that is :data:`True` if
+///     the array used indefinite-length encoding. This callback is invoked for each
+///     deserialized array, and its return value is substituted for the array in the
+///     deserialized output. It allows callers to preserve the distinction between
+///     definite- and indefinite-length arrays, which is otherwise lost after decoding.
 /// :param semantic_decoders:
 ///     An optional mapping for overriding the decoding for select semantic tags.
 ///     The value is a mapping of semantic tags (integers) to callables that take
@@ -182,6 +189,7 @@ pub struct CBORDecoder {
     fp: Option<Py<PyAny>>,
     tag_hook: Option<Py<PyAny>>,
     object_hook: Option<Py<PyAny>>,
+    array_hook: Option<Py<PyAny>>,
     semantic_decoders: Option<Py<PyMapping>>,
     str_errors: Option<Py<PyString>>,
     #[pyo3(get)]
@@ -207,6 +215,7 @@ impl CBORDecoder {
         buffer: Option<Bound<PyBytes>>,
         tag_hook: Option<&Bound<'_, PyAny>>,
         object_hook: Option<&Bound<'_, PyAny>>,
+        array_hook: Option<&Bound<'_, PyAny>>,
         semantic_decoders: Option<&Bound<'_, PyMapping>>,
         str_errors: &str,
         read_size: usize,
@@ -224,6 +233,7 @@ impl CBORDecoder {
             fp: None,
             tag_hook: None,
             object_hook: None,
+            array_hook: None,
             str_errors: None,
             read_size,
             max_depth,
@@ -241,6 +251,7 @@ impl CBORDecoder {
         };
         this.set_tag_hook(tag_hook)?;
         this.set_object_hook(object_hook)?;
+        this.set_array_hook(array_hook)?;
         this.set_str_errors(&bound_str_errors)?;
         Ok(this)
     }
@@ -529,20 +540,51 @@ impl CBORDecoder {
         immutable: bool,
     ) -> PyResult<DecoderResult<'py>> {
         // Major tag 4
+
+        // Apply the array_hook (if any) to a completed array, passing whether it used
+        // indefinite-length encoding. This lets callers preserve that distinction, which is
+        // otherwise lost once an array is decoded into a plain list/tuple.
+        #[inline]
+        fn maybe_call_array_hook<'py>(
+            py: Python<'py>,
+            value: Bound<'py, PyAny>,
+            indefinite: bool,
+            array_hook: Option<&Py<PyAny>>,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            if let Some(array_hook) = array_hook {
+                array_hook.bind(py).call1((value, indefinite))
+            } else {
+                Ok(value)
+            }
+        }
+
+        // `optional_length == None` signals an indefinite-length array; the definite-length
+        // completion sites below pass `false` and the indefinite (break-marker) sites pass `true`.
         let optional_length = self.decode_length_as_usize(py, subtype)?;
+        let array_hook = self.array_hook.as_ref().map(|hook| hook.clone_ref(py));
         if immutable {
             let mut items: Vec<Bound<'py, PyAny>> = Vec::new();
             let callback: Box<DecoderCallback<'py>> = if let Some(length) = optional_length {
                 if length == 0 {
-                    return Ok(Value(PyTuple::empty(py).into_any()));
+                    let value = PyTuple::empty(py).into_any();
+                    return Ok(Value(maybe_call_array_hook(
+                        py,
+                        value,
+                        false,
+                        array_hook.as_ref(),
+                    )?));
                 }
 
                 Box::new(move |item: Bound<'py, PyAny>, _immutable: bool| {
                     items.push(item);
                     if items.len() == length {
-                        Ok(CompleteFrame(
-                            PyTuple::new(py, take(&mut items))?.into_any(),
-                        ))
+                        let value = PyTuple::new(py, take(&mut items))?.into_any();
+                        Ok(CompleteFrame(maybe_call_array_hook(
+                            py,
+                            value,
+                            false,
+                            array_hook.as_ref(),
+                        )?))
                     } else {
                         Ok(ContinueFrame(false))
                     }
@@ -551,9 +593,13 @@ impl CBORDecoder {
                 let break_marker = BREAK_MARKER.get(py).unwrap().bind(py);
                 Box::new(move |item: Bound<'py, PyAny>, _immutable: bool| {
                     if item.is(break_marker) {
-                        Ok(CompleteFrame(
-                            PyTuple::new(py, take(&mut items))?.into_any(),
-                        ))
+                        let value = PyTuple::new(py, take(&mut items))?.into_any();
+                        Ok(CompleteFrame(maybe_call_array_hook(
+                            py,
+                            value,
+                            true,
+                            array_hook.as_ref(),
+                        )?))
                     } else {
                         items.push(item);
                         Ok(ContinueFrame(false))
@@ -571,15 +617,25 @@ impl CBORDecoder {
             let container = list.clone().into_any();
             let callback: Box<DecoderCallback<'py>> = if let Some(length) = optional_length {
                 if length == 0 {
-                    return Ok(Value(PyList::empty(py).into_any()));
+                    let value = PyList::empty(py).into_any();
+                    return Ok(Value(maybe_call_array_hook(
+                        py,
+                        value,
+                        false,
+                        array_hook.as_ref(),
+                    )?));
                 }
 
                 Box::new(move |item, _immutable: bool| {
                     list.append(item)?;
                     if list.len() == length {
-                        Ok(CompleteFrame(
-                            replace(&mut list, PyList::empty(py)).into_any(),
-                        ))
+                        let value = replace(&mut list, PyList::empty(py)).into_any();
+                        Ok(CompleteFrame(maybe_call_array_hook(
+                            py,
+                            value,
+                            false,
+                            array_hook.as_ref(),
+                        )?))
                     } else {
                         Ok(ContinueFrame(false))
                     }
@@ -588,9 +644,13 @@ impl CBORDecoder {
                 let break_marker = BREAK_MARKER.get(py).unwrap().bind(py);
                 Box::new(move |item: Bound<'py, PyAny>, _immutable: bool| {
                     if item.is(break_marker) {
-                        Ok(CompleteFrame(
-                            replace(&mut list, PyList::empty(py)).into_any(),
-                        ))
+                        let value = replace(&mut list, PyList::empty(py)).into_any();
+                        Ok(CompleteFrame(maybe_call_array_hook(
+                            py,
+                            value,
+                            true,
+                            array_hook.as_ref(),
+                        )?))
                     } else {
                         list.append(item)?;
                         Ok(ContinueFrame(false))
@@ -1355,6 +1415,7 @@ impl CBORDecoder {
         *,
         tag_hook = None,
         object_hook = None,
+        array_hook = None,
         semantic_decoders = None,
         str_errors = "strict",
         read_size = 4096,
@@ -1367,6 +1428,7 @@ impl CBORDecoder {
         fp: &Bound<'_, PyAny>,
         tag_hook: Option<&Bound<'_, PyAny>>,
         object_hook: Option<&Bound<'_, PyAny>>,
+        array_hook: Option<&Bound<'_, PyAny>>,
         semantic_decoders: Option<&Bound<'_, PyMapping>>,
         str_errors: &str,
         read_size: usize,
@@ -1380,6 +1442,7 @@ impl CBORDecoder {
             None,
             tag_hook,
             object_hook,
+            array_hook,
             semantic_decoders,
             str_errors,
             read_size,
@@ -1459,6 +1522,29 @@ impl CBORDecoder {
             self.object_hook = Some(object_hook.clone().unbind());
         } else {
             self.object_hook = None;
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn array_hook(&self, py: Python<'_>) -> Option<Py<PyAny>> {
+        self.array_hook
+            .as_ref()
+            .map(|array_hook| array_hook.clone_ref(py))
+    }
+
+    #[setter]
+    fn set_array_hook(&mut self, array_hook: Option<&Bound<'_, PyAny>>) -> PyResult<()> {
+        if let Some(array_hook) = array_hook {
+            if !array_hook.is_callable() {
+                return Err(PyErr::new::<PyTypeError, _>(
+                    "array_hook must be callable or None",
+                ));
+            }
+
+            self.array_hook = Some(array_hook.clone().unbind());
+        } else {
+            self.array_hook = None;
         }
         Ok(())
     }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -75,6 +75,13 @@ mod _cbor2 {
     ///     callable that takes 2 arguments: the decoder instance, and a dictionary. This
     ///     callback is invoked for each deserialized :class:`dict` object. The return value
     ///     is substituted for the dict in the deserialized output.
+    /// :param array_hook:
+    ///     callable that takes 2 arguments: the decoded array (a :class:`list`, or a
+    ///     :class:`tuple` when ``immutable`` is true), and a boolean that is :data:`True` if
+    ///     the array used indefinite-length encoding. This callback is invoked for each
+    ///     deserialized array, and its return value is substituted for the array in the
+    ///     deserialized output. It allows callers to preserve the distinction between
+    ///     definite- and indefinite-length arrays, which is otherwise lost after decoding.
     /// :param semantic_decoders:
     ///     An optional mapping for overriding the decoding for select semantic tags.
     ///     The value is a mapping of semantic tags (integers) to callables that take
@@ -105,6 +112,7 @@ mod _cbor2 {
         *,
         tag_hook = None,
         object_hook = None,
+        array_hook = None,
         semantic_decoders = None,
         str_errors = "strict",
         read_size = 4096,
@@ -118,6 +126,7 @@ mod _cbor2 {
         fp: &Bound<'py, PyAny>,
         tag_hook: Option<&Bound<'py, PyAny>>,
         object_hook: Option<&Bound<'py, PyAny>>,
+        array_hook: Option<&Bound<'py, PyAny>>,
         semantic_decoders: Option<&Bound<'py, PyMapping>>,
         str_errors: &str,
         read_size: usize,
@@ -131,6 +140,7 @@ mod _cbor2 {
             fp,
             tag_hook,
             object_hook,
+            array_hook,
             semantic_decoders,
             str_errors,
             read_size,
@@ -157,6 +167,13 @@ mod _cbor2 {
     ///     callable that takes 2 arguments: the decoder instance, and a dictionary. This
     ///     callback is invoked for each deserialized :class:`dict` object. The return value
     ///     is substituted for the dict in the deserialized output.
+    /// :param array_hook:
+    ///     callable that takes 2 arguments: the decoded array (a :class:`list`, or a
+    ///     :class:`tuple` when ``immutable`` is true), and a boolean that is :data:`True` if
+    ///     the array used indefinite-length encoding. This callback is invoked for each
+    ///     deserialized array, and its return value is substituted for the array in the
+    ///     deserialized output. It allows callers to preserve the distinction between
+    ///     definite- and indefinite-length arrays, which is otherwise lost after decoding.
     /// :param semantic_decoders:
     ///     An optional mapping for overriding the decoding for select semantic tags.
     ///     The value is a mapping of semantic tags (integers) to callables that take
@@ -185,6 +202,7 @@ mod _cbor2 {
         *,
         tag_hook = None,
         object_hook = None,
+        array_hook = None,
         semantic_decoders = None,
         str_errors = "strict",
         max_depth = 400,
@@ -197,6 +215,7 @@ mod _cbor2 {
         data: &Bound<'py, PyAny>,
         tag_hook: Option<&Bound<'py, PyAny>>,
         object_hook: Option<&Bound<'py, PyAny>>,
+        array_hook: Option<&Bound<'py, PyAny>>,
         semantic_decoders: Option<&Bound<'py, PyMapping>>,
         str_errors: &str,
         max_depth: usize,
@@ -223,6 +242,7 @@ mod _cbor2 {
             Some(bytes),
             tag_hook,
             object_hook,
+            array_hook,
             semantic_decoders,
             str_errors,
             0,

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -6,7 +6,7 @@ import re
 import struct
 import sys
 from binascii import unhexlify
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
@@ -1040,6 +1040,104 @@ def test_object_hook_exception() -> None:
     payload = unhexlify("A2616103616205")
     with pytest.raises(CBORDecodeError) as exc_info:
         loads(payload, object_hook=object_hook)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert exc_info.value.__cause__.args[0] == "foo"
+
+
+class TestArrayHookAttribute:
+    def test_success(self) -> None:
+        def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+            return value
+
+        decoder = CBORDecoder(BytesIO(), array_hook=array_hook)
+        assert decoder.array_hook is array_hook
+
+    def test_not_callable(self) -> None:
+        with pytest.raises(TypeError, match="array_hook must be callable or None"):
+            CBORDecoder(BytesIO(), array_hook="foo")  # type: ignore[arg-type]
+
+    def test_delete(self) -> None:
+        decoder = CBORDecoder(BytesIO())
+        with pytest.raises(AttributeError):
+            del decoder.array_hook
+
+
+def test_array_hook_definite() -> None:
+    """A definite-length array invokes the hook with indefinite=False."""
+    calls: list[tuple[Any, bool]] = []
+
+    def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+        calls.append((list(value), indefinite))
+        return value
+
+    decoded = loads(unhexlify("83010203"), array_hook=array_hook)
+    assert decoded == [1, 2, 3]
+    assert calls == [([1, 2, 3], False)]
+
+
+def test_array_hook_indefinite() -> None:
+    """An indefinite-length array invokes the hook with indefinite=True."""
+    calls: list[tuple[Any, bool]] = []
+
+    def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+        calls.append((list(value), indefinite))
+        return value
+
+    decoded = loads(unhexlify("9f010203ff"), array_hook=array_hook)
+    assert decoded == [1, 2, 3]
+    assert calls == [([1, 2, 3], True)]
+
+
+def test_array_hook_return_value_replaces() -> None:
+    """The hook's return value replaces the decoded array, preserving indefiniteness."""
+
+    class IndefiniteList(list[Any]):
+        pass
+
+    def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+        return IndefiniteList(value) if indefinite else list(value)
+
+    definite = loads(unhexlify("83010203"), array_hook=array_hook)
+    indefinite = loads(unhexlify("9f010203ff"), array_hook=array_hook)
+    assert type(definite) is list
+    assert type(indefinite) is IndefiniteList
+    assert definite == indefinite == [1, 2, 3]
+
+
+def test_array_hook_nested() -> None:
+    """The hook fires for each array with the correct indefinite flag, innermost first."""
+    calls: list[tuple[Any, bool]] = []
+
+    def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+        calls.append((list(value), indefinite))
+        return value
+
+    # Definite outer array containing one indefinite inner array: 81 9f 01 02 ff
+    decoded = loads(unhexlify("819f0102ff"), array_hook=array_hook)
+    assert decoded == [[1, 2]]
+    assert calls == [([1, 2], True), ([[1, 2]], False)]
+
+
+def test_array_hook_immutable() -> None:
+    """Under immutable=True arrays are tuples; the hook still reports indefiniteness."""
+    calls: list[tuple[Any, bool]] = []
+
+    def array_hook(value: Sequence[Any], indefinite: bool) -> Sequence[Any]:
+        calls.append((tuple(value), indefinite))
+        return value
+
+    decoded = loads(unhexlify("9f010203ff"), array_hook=array_hook, immutable=True)
+    assert decoded == (1, 2, 3)
+    assert calls == [((1, 2, 3), True)]
+
+
+def test_array_hook_exception() -> None:
+    def array_hook(value: Sequence[Any], indefinite: bool) -> NoReturn:
+        raise RuntimeError("foo")
+
+    with pytest.raises(CBORDecodeError) as exc_info:
+        loads(unhexlify("83010203"), array_hook=array_hook)
 
     assert isinstance(exc_info.value.__cause__, RuntimeError)
     assert exc_info.value.__cause__.args[0] == "foo"


### PR DESCRIPTION
# PR 1 — Add `array_hook` to surface indefinite-length arrays on decode

**Branch:** `feature/array-hook`

## Problem
cbor2 6.x decodes definite- and indefinite-length arrays into the same Python type (`list`, or `tuple` under `immutable=True`), discarding the length-encoding distinction. There is no decoder hook or return-type difference that lets a caller observe whether a given array used indefinite-length (`0x9f … 0xff`) encoding.

This makes **byte-exact round-tripping impossible** for callers that must reproduce the original encoding — e.g. anything that decodes CBOR, transforms it, and re-encodes it for hashing or signature verification (the Cardano ecosystem relies on this). The encoder already supports emitting indefinite containers; only the decode direction lacks a way to preserve the information.

## Solution
Add an `array_hook` decoder callback, mirroring the existing `object_hook`. It is invoked for every decoded array with `(value, indefinite)`:
- `value` — the decoded array (`list`, or `tuple` under `immutable=True`)
- `indefinite` — `True` if the array used indefinite-length encoding

Its return value replaces the array in the output. `indefinite` is precisely the one piece of metadata a caller cannot otherwise recover (immutability is already inferable from the value's type), which is why it's passed explicitly.

```python
from cbor2 import loads
def array_hook(value, indefinite):
    return MyIndefiniteList(value) if indefinite else value
loads(data, array_hook=array_hook)
```

Default is `None` → today's behavior, zero breakage.

## Changes
- `rust/decoder.rs`: `array_hook` field, constructor param, getter/setter (with callable validation), and a `maybe_call_array_hook` helper applied at every `decode_array` completion site (definite → `False`, indefinite → `True`, including empty arrays).
- `rust/lib.rs`: `array_hook` threaded through `load()`/`loads()` + docstrings.
- `python/cbor2/__init__.pyi`: `ArrayHook` type alias on `CBORDecoder`, `load`, `loads`.
- `tests/test_decoder.py`: 9 tests — attribute get/set/not-callable/delete, definite, indefinite, return-replacement, nested, immutable/tuple, exception propagation.
- changelog entry.

## Verification
`cargo check --deny warnings` + clippy clean; full test suite passes (441 baseline + 9 new = 450).
