### PR TITLE
Decode unknown-tag content according to the immutable flag

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the content of a semantic tag with no designated decoder being decoded as immutable
+  (``tuple``/``frozendict``) regardless of the ``immutable`` flag. The nested array/map of such a
+  tag now honours ``immutable`` like every other container. This is a further instance of the
+  mutability bug fixed in 6.0.1 (`#295 <https://github.com/agronholm/cbor2/issues/295>`_).
+
 **6.1.2** (2026-06-02)
 
 - Fixed incorrect tracking of string references for definite-length text strings of length greater

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,12 +5,15 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- **BACKWARD INCOMPATIBLE** Changed the content of a semantic tag to be decoded to adhere to the
+  current "immutable" status of the decoder stack (i.e. when decoding a map key, immutable would
+  be set to ``true``) instead of always decoding as immutable
+  (`#295 <https://github.com/agronholm/cbor2/issues/295>`_)
+
 **6.1.3** (2026-07-04)
 
-- Fixed the content of a semantic tag with no designated decoder being decoded as immutable
-  (``tuple``/``frozendict``) regardless of the ``immutable`` flag. The nested array/map of such a
-  tag now honours ``immutable`` like every other container. This is a further instance of the
-  mutability bug fixed in 6.0.1 (`#295 <https://github.com/agronholm/cbor2/issues/295>`_).
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -922,7 +922,7 @@ impl CBORDecoder {
                 });
                 return Ok(BeginFrame(
                     callback,
-                    true,
+                    immutable,
                     Some(container),
                     DisplayName::SemanticTag(tagnum),
                 ));

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1022,6 +1022,22 @@ def test_tag_hook() -> None:
     assert decoded == "olleH"
 
 
+def test_unknown_tag_value_respects_immutable() -> None:
+    # The content of a tag with no designated decoder must honour the ``immutable``
+    # flag, like every other container. Previously it was always decoded immutable.
+    payload = dumps(CBORTag(6000, [1, 2, 3]))
+    mutable = loads(payload)
+    assert isinstance(mutable.value, list)
+    immutable = loads(payload, immutable=True)
+    assert isinstance(immutable.value, tuple)
+
+    map_payload = dumps(CBORTag(6000, {"a": 1}))
+    assert isinstance(loads(map_payload).value, dict)
+    immutable_map = loads(map_payload, immutable=True).value
+    assert not isinstance(immutable_map, dict)
+    assert immutable_map["a"] == 1
+
+
 def test_object_hook() -> None:
     class DummyType:
         def __init__(self, state: Mapping[Any, Any], immutable: bool) -> None:

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1104,7 +1104,7 @@ def test_unknown_tag_value_respects_immutable() -> None:
     map_payload = dumps(CBORTag(6000, {"a": 1}))
     assert isinstance(loads(map_payload).value, dict)
     immutable_map = loads(map_payload, immutable=True).value
-    assert not isinstance(immutable_map, dict)
+    assert isinstance(immutable_map, frozendict)
     assert immutable_map["a"] == 1
 
 


### PR DESCRIPTION
# PR 2 — Decode unknown-tag content according to the `immutable` flag

**Branch:** `fix/tag-content-immutable`

## Problem
The content of a semantic tag with **no designated decoder** is always decoded as immutable — `tuple` for arrays, `frozendict` for maps — regardless of the decoder's `immutable` flag.

Every other container honours `immutable`: top-level arrays/maps, nested arrays/maps, and even the tag-258 (set) decoder all thread the flag through. Only the generic-tag arm in `decode_semantic` hardcodes `true`:

```rust
return Ok(BeginFrame(
    callback,
    true,            // <-- ignores `immutable`
    Some(container),
    DisplayName::SemanticTag(tagnum),
));
```

So `cbor2.loads(cbor2.dumps(CBORTag(6000, [1, 2, 3]))).value` is a `tuple`, even though the caller asked for (default) mutable decoding.

This:
- surprises callers who decode with `immutable=False` and then try to mutate a tag's array/map value;
- breaks downstream libraries that assume `cbor2.loads(tagged).value` is a `list` — the behavior of cbor2 ≤ 5.x. (Concretely, this is what breaks `pycose`'s `CoseMessage.decode`, which does `isinstance(value, list)` and `value.pop(0)`.)

It is a further instance of the mutability bug fixed in 6.0.1 (#295, "values being decoded as immutable in unexpected places").

## Solution
Thread the `immutable` flag through the generic-tag `BeginFrame` so tag content honours it like every other container (`true` → `immutable`).

## Changes
- `rust/decoder.rs`: one-line fix in `decode_semantic`'s generic-tag arm.
- `tests/test_decoder.py`: `test_unknown_tag_value_respects_immutable` — array content is `list` by default / `tuple` under `immutable=True`; map content is `dict` / non-`dict` mapping respectively.
- changelog entry.

## Verification
Full test suite passes (442); no existing test depended on tag content being immutable.
