### PR TITLE
measure text strings by byte length in maybe_stringref

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed the encoder measuring text strings by code point count instead of UTF-8 byte length when
-  deciding whether to add them to the string reference namespace, desynchronising it from the
-  decoder (which counts bytes) and corrupting later string references for non-ASCII strings
-  (`#314 <https://github.com/agronholm/cbor2/pull/314>`_; PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value
@@ -25,6 +21,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``datetime_as_timestamp`` encoding whole-second datetimes before 1970 or after 2106 as
   floats instead of integers, because the timestamp was narrowed through an unsigned 32-bit integer
   (`#317 <https://github.com/agronholm/cbor2/pull/317>`_; PR by @sahvx655-wq)
+- Fixed the encoder measuring text strings by code point count instead of UTF-8 byte length when
+  deciding whether to add them to the string reference namespace, desynchronising it from the
+  decoder (which counts bytes) and corrupting later string references for non-ASCII strings
+  (`#314 <https://github.com/agronholm/cbor2/pull/314>`_; PR by @sahvx655-wq)
 
 **6.1.2** (2026-06-02)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed the encoder measuring text strings by code point count instead of UTF-8 byte length when
+  deciding whether to add them to the string reference namespace, desynchronising it from the
+  decoder (which counts bytes) and corrupting later string references for non-ASCII strings
+  (`#314 <https://github.com/agronholm/cbor2/pull/314>`_; PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -303,12 +303,19 @@ impl CBOREncoder {
     fn maybe_stringref(slf: &Bound<'_, Self>, value: &Bound<'_, PyAny>) -> PyResult<bool> {
         let py = slf.py();
         let mut this = slf.borrow_mut();
-        let (index, is_string) = if let Ok(py_string) = value.cast::<PyString>() {
+        let (index, is_string, length) = if let Ok(py_string) = value.cast::<PyString>() {
             let string: String = py_string.extract()?;
-            (this.string_references.get(&string).copied(), true)
+            // The threshold compares against the string's encoded size, which for text is the
+            // number of UTF-8 bytes, not the number of code points
+            (
+                this.string_references.get(&string).copied(),
+                true,
+                string.len(),
+            )
         } else {
             let bytes: Vec<u8> = value.cast::<PyBytes>()?.extract()?;
-            (this.bytes_references.get(&bytes).copied(), false)
+            let length = bytes.len();
+            (this.bytes_references.get(&bytes).copied(), false, length)
         };
         match index {
             Some(index) => {
@@ -317,7 +324,6 @@ impl CBOREncoder {
                 Ok(true)
             }
             None => {
-                let length = value.len()?;
                 let next_index = this.string_references.len() + this.bytes_references.len();
                 let is_referenced = match next_index {
                     ..24 => length >= 3,

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -314,8 +314,7 @@ impl CBOREncoder {
             )
         } else {
             let bytes: Vec<u8> = value.cast::<PyBytes>()?.extract()?;
-            let length = bytes.len();
-            (this.bytes_references.get(&bytes).copied(), false, length)
+            (this.bytes_references.get(&bytes).copied(), false, bytes.len())
         };
         match index {
             Some(index) => {

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -305,8 +305,6 @@ impl CBOREncoder {
         let mut this = slf.borrow_mut();
         let (index, is_string, length) = if let Ok(py_string) = value.cast::<PyString>() {
             let string: String = py_string.extract()?;
-            // The threshold compares against the string's encoded size, which for text is the
-            // number of UTF-8 bytes, not the number of code points
             (
                 this.string_references.get(&string).copied(),
                 true,

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -314,7 +314,11 @@ impl CBOREncoder {
             )
         } else {
             let bytes: Vec<u8> = value.cast::<PyBytes>()?.extract()?;
-            (this.bytes_references.get(&bytes).copied(), false, bytes.len())
+            (
+                this.bytes_references.get(&bytes).copied(),
+                false,
+                bytes.len(),
+            )
         };
         match index {
             Some(index) => {

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -677,6 +677,16 @@ def test_encode_stringrefs_datetime() -> None:
     assert dumps(value, string_referencing=True) == expected
 
 
+def test_encode_stringrefs_non_ascii() -> None:
+    # "€€" is 2 code points but 6 UTF-8 bytes; the reference threshold is measured in
+    # encoded bytes, so it must be registered (index 0) just like the decoder counts it
+    value = ["€€", "abc", "abc"]
+    encoded = dumps(value, string_referencing=True)
+    expected = unhexlify("d901008366e282ace282ac63616263d81901")
+    assert encoded == expected
+    assert loads(encoded) == value
+
+
 @pytest.mark.parametrize(
     "tag",
     [


### PR DESCRIPTION
**String reference threshold counts code points, not encoded bytes**

While following up on the namespace fix in #313 I lined `maybe_stringref` up against the decoder and found a second place they disagree that the threshold table does not cover: the encoder decides whether to register a string with `value.len()`, which for a `str` is the number of code points, while the length written on the wire and the decoder both count UTF-8 bytes. For any non-ASCII text the two sides then make opposite decisions about crossing the 3/4/5/7/11-byte threshold, the namespace indices drift apart, and subsequent tag 25 references resolve to the wrong earlier string, so the payload comes back silently corrupted instead of erroring. The text branch now measures UTF-8 byte length to match the decoder and the encoded form; bytestrings were already counted in bytes. The added regression round-trips a non-ASCII payload that previously decoded incorrectly.