### PR TITLE
avoid quadratic concatenation when decoding chunked strings

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed quadratic decoding time for indefinite-length and large definite-length byte and text
-  strings, caused by concatenating each chunk onto the accumulated result with ``+`` instead of
-  building the result once
-  (`#316 <https://github.com/agronholm/cbor2/pull/316>`_; PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value
@@ -18,6 +14,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed the IPv4/IPv6 network decoders (tags 52 and 54) silently truncating an address byte string
   that is longer than the address size instead of rejecting it as malformed
   (`#309 <https://github.com/agronholm/cbor2/pull/309>`_; PR by @sahvx655-wq)
+- Fixed quadratic decoding time for indefinite-length and large definite-length byte and text
+  strings, caused by concatenating each chunk onto the accumulated result with ``+`` instead of
+  building the result once
+  (`#316 <https://github.com/agronholm/cbor2/pull/316>`_; PR by @sahvx655-wq)
 
 **6.1.2** (2026-06-02)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed quadratic decoding time for indefinite-length and large definite-length byte and text
+  strings, caused by concatenating each chunk onto the accumulated result with ``+`` instead of
+  building the result once
+  (`#316 <https://github.com/agronholm/cbor2/pull/316>`_; PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -428,9 +428,9 @@ impl CBORDecoder {
             Some(length) => {
                 // Incrementally read the bytestring, in chunks of 65536 bytes. The claimed
                 // length is untrusted until the data has actually been read, so no more than
-                // 1 MiB of it is reserved up front; a truncated payload claiming a huge length
-                // can then force at most a 1 MiB allocation.
-                let bytes = PyBytes::new_with_writer(py, length.min(1_048_576), |writer| {
+                // 64 KiB of it is reserved up front; a truncated payload claiming a huge length
+                // can then force at most a 64 KiB allocation.
+                let bytes = PyBytes::new_with_writer(py, length.min(65536), |writer| {
                     let mut remaining_length = length;
                     while remaining_length > 0 {
                         let chunk_size = remaining_length.min(65536);

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -21,7 +21,6 @@ use pyo3::types::{
 };
 use pyo3::{IntoPyObjectExt, Py, PyAny, PyErrArguments, intern, pyclass};
 use std::fmt::{Display, Formatter};
-use std::io::Write;
 use std::mem::{replace, take};
 
 const IMMUTABLE_ATTR: &str = "_cbor2_immutable";
@@ -428,9 +427,10 @@ impl CBORDecoder {
             }
             Some(length) => {
                 // Incrementally read the bytestring, in chunks of 65536 bytes. The claimed
-                // length is not reserved up front, as it is untrusted until the data has
-                // actually been read.
-                let bytes = PyBytes::new_with_writer(py, 0, |writer| {
+                // length is untrusted until the data has actually been read, so no more than
+                // 1 MiB of it is reserved up front; a truncated payload claiming a huge length
+                // can then force at most a 1 MiB allocation.
+                let bytes = PyBytes::new_with_writer(py, length.min(1_048_576), |writer| {
                     let mut remaining_length = length;
                     while remaining_length > 0 {
                         let chunk_size = remaining_length.min(65536);

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -14,7 +14,6 @@ use crate::utils::{PyImportable, create_exc_from, raise_exc_from};
 use half::f16;
 use pyo3::exceptions::{PyException, PyLookupError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::sync::PyOnceLock;
 use pyo3::types::{
     PyBytes, PyCFunction, PyComplex, PyDict, PyFrozenSet, PyInt, PyList, PyListMethods, PyMapping,
     PySet, PyString, PyTuple,
@@ -34,7 +33,6 @@ static DATETIME_FROMISOFORMAT: PyImportable =
 static DATETIME_FROMTIMESTAMP: PyImportable =
     PyImportable::new("datetime", "datetime.fromtimestamp");
 static EMAIL_PARSER: PyImportable = PyImportable::new("email.parser", "Parser");
-static INCREMENTAL_UTF8_DECODER: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 static INT_FROMBYTES: PyImportable = PyImportable::new("builtins", "int.from_bytes");
 static IPADDRESS_FUNC: PyImportable = PyImportable::new("ipaddress", "ip_address");
 static IPNETWORK_FUNC: PyImportable = PyImportable::new("ipaddress", "ip_network");
@@ -503,35 +501,41 @@ impl CBORDecoder {
                 Ok(StringValue(decoded_string, length))
             }
             Some(length) => {
-                // Incrementally decode the string, in chunks of 65536 bytes
-                let decoder_class = INCREMENTAL_UTF8_DECODER
-                    .get_or_try_init(py, || -> PyResult<Py<PyAny>> {
-                        let decoder = py
-                            .import("codecs")?
-                            .getattr("lookup")?
-                            .call1(("utf-8",))?
-                            .getattr("incrementaldecoder")?;
-                        Ok(decoder.unbind())
-                    })?
-                    .bind(py);
-                let decoder = match self.str_errors.as_ref() {
-                    None => decoder_class.call0()?,
-                    Some(str_errors) => decoder_class.call1((str_errors,))?,
+                // Read the string into a single bytes object in chunks of 65536 bytes, then
+                // decode it in one pass. As with the bytestring path, the claimed length is
+                // untrusted until the data has actually been read, so no more than 64 KiB of it
+                // is reserved up front; a truncated payload claiming a huge length can then force
+                // at most a 64 KiB allocation. Decoding the assembled bytes as a whole also keeps
+                // multi-byte characters straddling a chunk boundary intact, so no incremental
+                // decoder is needed.
+                let bytes = PyBytes::new_with_writer(py, length.min(65536), |writer| {
+                    let mut remaining_length = length;
+                    while remaining_length > 0 {
+                        let chunk_size = remaining_length.min(65536);
+                        let chunk = self.read(py, chunk_size)?;
+                        remaining_length -= chunk_size;
+                        writer.write_all(&chunk)?;
+                    }
+                    Ok(())
+                })?;
+                let errors = match self.str_errors.as_ref() {
+                    None => None,
+                    // set_str_errors only ever stores these values
+                    Some(str_errors) => Some(match str_errors.to_str(py)? {
+                        "ignore" => c"ignore",
+                        "replace" => c"replace",
+                        "backslashreplace" => c"backslashreplace",
+                        "surrogateescape" => c"surrogateescape",
+                        other => {
+                            return Err(CBORDecodeError::new_err(format!(
+                                "invalid str_errors value: '{other}'"
+                            )));
+                        }
+                    }),
                 };
-                let mut parts: Vec<Bound<'py, PyAny>> = Vec::new();
-                let mut remaining_length = length;
-                while remaining_length > 0 {
-                    let chunk_size = remaining_length.min(65536);
-                    let chunk = self.read(py, chunk_size)?;
-                    remaining_length -= chunk_size;
-                    let is_final_chunk = remaining_length == 0;
-                    let decoded_chunk =
-                        decoder.call_method1(intern!(py, "decode"), (chunk, is_final_chunk))?;
-                    parts.push(decoded_chunk);
-                }
-                let joined = PyString::new(py, "")
-                    .call_method1(intern!(py, "join"), (PyList::new(py, parts)?,))?;
-                Ok(StringValue(joined.into_any(), length))
+                let decoded =
+                    PyString::from_encoded_object(bytes.as_any(), Some(c"utf-8"), errors)?;
+                Ok(StringValue(decoded.into_any(), length))
             }
         }
     }

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -393,7 +393,7 @@ impl CBORDecoder {
         match self.decode_length_as_usize(py, subtype)? {
             None => {
                 // Indefinite length
-                let mut bytes = PyBytes::new(py, b"");
+                let mut buffer: Vec<u8> = Vec::new();
                 let sys_maxsize = *SYS_MAXSIZE.get(py).unwrap();
                 loop {
                     let (major_type, subtype) = self.read_major_and_subtype(py)?;
@@ -407,9 +407,9 @@ impl CBORDecoder {
                             }
                             let length = length as usize;
                             let chunk = self.read(py, length)?;
-                            bytes = bytes.add(chunk)?.cast_into()?;
+                            buffer.extend_from_slice(&chunk);
                         }
-                        (7, 31) => break Ok(Value(bytes.into_any())), // break marker
+                        (7, 31) => break Ok(Value(PyBytes::new(py, &buffer).into_any())), // break marker
                         _ => {
                             return Err(CBORDecodeError::new_err(format!(
                                 "non-byte string (major type {major_type}) found in indefinite \
@@ -425,15 +425,15 @@ impl CBORDecoder {
             }
             Some(length) => {
                 // Incrementally read the bytestring, in chunks of 65536 bytes
-                let mut bytes = PyBytes::new(py, b"");
+                let mut buffer: Vec<u8> = Vec::new();
                 let mut remaining_length = length;
                 while remaining_length > 0 {
                     let chunk_size = remaining_length.min(65536);
                     let chunk = self.read(py, chunk_size)?;
                     remaining_length -= chunk_size;
-                    bytes = bytes.add(chunk)?.cast_into()?;
+                    buffer.extend_from_slice(&chunk);
                 }
-                Ok(StringValue(bytes.into_any(), length))
+                Ok(StringValue(PyBytes::new(py, &buffer).into_any(), length))
             }
         }
     }
@@ -443,7 +443,7 @@ impl CBORDecoder {
         match self.decode_length_as_usize(py, subtype)? {
             None => {
                 // Indefinite length
-                let mut string = PyString::new(py, "");
+                let mut parts: Vec<Bound<'py, PyString>> = Vec::new();
                 loop {
                     let (major_type, subtype) = self.read_major_and_subtype(py)?;
                     let sys_maxsize = *SYS_MAXSIZE.get(py).unwrap();
@@ -467,9 +467,14 @@ impl CBORDecoder {
                                     )
                                     .and_then(|string| string.cast_into().map_err(PyErr::from)),
                             }?;
-                            string = string.add(decoded)?.cast_into()?;
+                            parts.push(decoded);
                         }
-                        (7, 31) => break Ok(Value(string.into_any())), // break marker
+                        (7, 31) => {
+                            // break marker
+                            break PyString::new(py, "")
+                                .call_method1(intern!(py, "join"), (PyList::new(py, parts)?,))
+                                .map(|joined| Value(joined.into_any()));
+                        }
                         _ => {
                             return Err(CBORDecodeError::new_err(format!(
                                 "non-text string (major type {major_type}) found in indefinite \
@@ -506,7 +511,7 @@ impl CBORDecoder {
                     None => decoder_class.call0()?,
                     Some(str_errors) => decoder_class.call1((str_errors,))?,
                 };
-                let mut string = PyString::new(py, "").into_any();
+                let mut parts: Vec<Bound<'py, PyAny>> = Vec::new();
                 let mut remaining_length = length;
                 while remaining_length > 0 {
                     let chunk_size = remaining_length.min(65536);
@@ -515,9 +520,11 @@ impl CBORDecoder {
                     let is_final_chunk = remaining_length == 0;
                     let decoded_chunk =
                         decoder.call_method1(intern!(py, "decode"), (chunk, is_final_chunk))?;
-                    string = string.add(decoded_chunk)?;
+                    parts.push(decoded_chunk);
                 }
-                Ok(StringValue(string.into_any(), length))
+                let joined = PyString::new(py, "")
+                    .call_method1(intern!(py, "join"), (PyList::new(py, parts)?,))?;
+                Ok(StringValue(joined.into_any(), length))
             }
         }
     }

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -21,6 +21,7 @@ use pyo3::types::{
 };
 use pyo3::{IntoPyObjectExt, Py, PyAny, PyErrArguments, intern, pyclass};
 use std::fmt::{Display, Formatter};
+use std::io::Write;
 use std::mem::{replace, take};
 
 const IMMUTABLE_ATTR: &str = "_cbor2_immutable";
@@ -393,47 +394,53 @@ impl CBORDecoder {
         match self.decode_length_as_usize(py, subtype)? {
             None => {
                 // Indefinite length
-                let mut buffer: Vec<u8> = Vec::new();
                 let sys_maxsize = *SYS_MAXSIZE.get(py).unwrap();
-                loop {
-                    let (major_type, subtype) = self.read_major_and_subtype(py)?;
-                    match (major_type, subtype) {
-                        (2, _) => {
-                            let length = self.decode_length_finite(py, subtype)?;
-                            if length > sys_maxsize {
+                let bytes = PyBytes::new_with_writer(py, 0, |writer| {
+                    loop {
+                        let (major_type, subtype) = self.read_major_and_subtype(py)?;
+                        match (major_type, subtype) {
+                            (2, _) => {
+                                let length = self.decode_length_finite(py, subtype)?;
+                                if length > sys_maxsize {
+                                    return Err(CBORDecodeError::new_err(format!(
+                                        "chunk too long in an indefinite bytestring chunk: {length}"
+                                    )));
+                                }
+                                let length = length as usize;
+                                let chunk = self.read(py, length)?;
+                                writer.write_all(&chunk)?;
+                            }
+                            (7, 31) => break Ok(()), // break marker
+                            _ => {
                                 return Err(CBORDecodeError::new_err(format!(
-                                    "chunk too long in an indefinite bytestring chunk: {length}"
+                                    "non-byte string (major type {major_type}) found in indefinite \
+                                    length byte string"
                                 )));
                             }
-                            let length = length as usize;
-                            let chunk = self.read(py, length)?;
-                            buffer.extend_from_slice(&chunk);
-                        }
-                        (7, 31) => break Ok(Value(PyBytes::new(py, &buffer).into_any())), // break marker
-                        _ => {
-                            return Err(CBORDecodeError::new_err(format!(
-                                "non-byte string (major type {major_type}) found in indefinite \
-                                    length byte string"
-                            )));
                         }
                     }
-                }
+                })?;
+                Ok(Value(bytes.into_any()))
             }
             Some(length) if length <= 65536 => {
                 let bytes = self.read(py, length)?;
                 Ok(StringValue(PyBytes::new(py, &bytes).into_any(), length))
             }
             Some(length) => {
-                // Incrementally read the bytestring, in chunks of 65536 bytes
-                let mut buffer: Vec<u8> = Vec::new();
-                let mut remaining_length = length;
-                while remaining_length > 0 {
-                    let chunk_size = remaining_length.min(65536);
-                    let chunk = self.read(py, chunk_size)?;
-                    remaining_length -= chunk_size;
-                    buffer.extend_from_slice(&chunk);
-                }
-                Ok(StringValue(PyBytes::new(py, &buffer).into_any(), length))
+                // Incrementally read the bytestring, in chunks of 65536 bytes. The claimed
+                // length is not reserved up front, as it is untrusted until the data has
+                // actually been read.
+                let bytes = PyBytes::new_with_writer(py, 0, |writer| {
+                    let mut remaining_length = length;
+                    while remaining_length > 0 {
+                        let chunk_size = remaining_length.min(65536);
+                        let chunk = self.read(py, chunk_size)?;
+                        remaining_length -= chunk_size;
+                        writer.write_all(&chunk)?;
+                    }
+                    Ok(())
+                })?;
+                Ok(StringValue(bytes.into_any(), length))
             }
         }
     }

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -27,6 +27,7 @@ from ipaddress import (
 )
 from pathlib import Path
 from socket import socketpair
+from time import perf_counter
 from typing import Any, NoReturn
 from uuid import UUID
 
@@ -420,6 +421,29 @@ def test_string_issue_264_multiple_chunks_utf8_boundary() -> None:
     result = loads(payload)
     assert result == expected
     assert len(result) == 131170  # 65535 + 1 + 65533 + 1 + 100 characters
+
+
+def test_indefinite_bytestring_many_chunks() -> None:
+    # An indefinite-length byte string assembled from many single-byte chunks used to be
+    # concatenated with repeated "+", which is quadratic in the number of chunks. The time
+    # bound is generous; only the quadratic behaviour blows past it.
+    count = 400000
+    payload = b"\x5f" + b"\x41\x2a" * count + b"\xff"
+    start = perf_counter()
+    result = loads(payload)
+    assert perf_counter() - start < 2.0
+    assert result == b"\x2a" * count
+
+
+def test_indefinite_string_many_chunks() -> None:
+    # Same quadratic concatenation issue for indefinite-length text strings; the final chunk
+    # carries a multi-byte character to exercise the join path.
+    count = 400000
+    payload = b"\x7f" + b"\x61\x61" * (count - 1) + b"\x62\xc3\xb6" + b"\xff"
+    start = perf_counter()
+    result = loads(payload)
+    assert perf_counter() - start < 2.0
+    assert result == "a" * (count - 1) + "ö"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

Decoding an indefinite-length byte or text string assembles the result by concatenating each chunk onto the running value with `+` (`bytes.add`/`string.add` in `decode_bytestring`/`decode_string`). Every `+` allocates a fresh object and copies the whole accumulator, so a string delivered as N chunks costs O(N^2). I ran into it while profiling a decode of a payload made of many tiny indefinite chunks: a 320 KiB input of single-byte chunks sat at roughly 680 ms, and the time quadruples each time the chunk count doubles. The same construct is used on the large definite-length (>65536 byte) paths. As the decoder runs over untrusted input with the default settings, a small crafted payload of many one-byte chunks turns into seconds of CPU and a lot of short-lived allocation, so the practical effect is a cheap denial of service rather than merely a slow path.

The original pure-Python decoder gathered the chunks in a list and did a single `b"".join`/`"".join` at the end, which is linear, and I have restored that shape here. Byte chunks accumulate into a `Vec<u8>` that becomes one `bytes` object, and text chunks accumulate into a list joined once, with the join kept in Python so the `str_errors` surrogate handling is untouched. The same input now decodes in about 9 ms and scales linearly. Keeping the assembly at the point where the chunks are read means every string path benefits without any caller change.

Before/after on indefinite byte strings of single-byte chunks:

```
chunks    input     before      after
 40000     80 KiB    21.6 ms     2.4 ms
 80000    160 KiB   130.3 ms     5.0 ms
160000    320 KiB   682.4 ms     9.3 ms
```

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
