### PR TITLE
encode whole-second datetime timestamps as integers across full range

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``datetime_as_timestamp`` encoding whole-second datetimes before 1970 or after 2106 as
+  floats instead of integers, because the timestamp was narrowed through an unsigned 32-bit integer
+  (PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,9 +7,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed ``datetime_as_timestamp`` encoding whole-second datetimes before 1970 or after 2106 as
-  floats instead of integers, because the timestamp was narrowed through an unsigned 32-bit integer
-  (PR by @sahvx655-wq)
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices
   65536–4294967295 where the encoder does not, desynchronising the namespace and resolving later
   string references to the wrong value
@@ -21,6 +18,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   strings, caused by concatenating each chunk onto the accumulated result with ``+`` instead of
   building the result once
   (`#316 <https://github.com/agronholm/cbor2/pull/316>`_; PR by @sahvx655-wq)
+- Fixed ``datetime_as_timestamp`` encoding whole-second datetimes before 1970 or after 2106 as
+  floats instead of integers, because the timestamp was narrowed through an unsigned 32-bit integer
+  (`#317 <https://github.com/agronholm/cbor2/pull/317>`_; PR by @sahvx655-wq)
 
 **6.1.2** (2026-06-02)
 

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -966,7 +966,7 @@ impl CBOREncoder {
                     // If the timestamp can be converted to an integer without loss, encode that
                     // integer instead
                     let timestamp_float: f64 = py_timestamp.extract()?;
-                    let timestamp_int: u32 = timestamp_float as u32;
+                    let timestamp_int: i64 = timestamp_float as i64;
                     let arg: Bound<'_, PyAny> = if timestamp_int as f64 == timestamp_float {
                         PyInt::new(py, timestamp_int).into_any()
                     } else {

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -299,6 +299,18 @@ def test_simple_val_as_key() -> None:
             "c11a514b67b0",
             id="timestamp/eet",
         ),
+        pytest.param(
+            datetime(1969, 12, 31, 0, 0, 0, tzinfo=timezone.utc),
+            True,
+            "c13a0001517f",
+            id="timestamp/pre-epoch",
+        ),
+        pytest.param(
+            datetime(2200, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            True,
+            "c11b00000001b09e1900",
+            id="timestamp/post-2106",
+        ),
     ],
 )
 def test_datetime(value: datetime, as_timestamp: bool, expected: str) -> None:


### PR DESCRIPTION
## Changes

Under `datetime_as_timestamp`, `encode_datetime` decides whether a value can be written as an integer by narrowing the POSIX timestamp through a `u32` and comparing it back against the float. That cast saturates: anything negative collapses to 0 and anything past 2106-02-07 collapses to `u32::MAX`, so the equality check never holds for a whole-second datetime before 1970 or after 2106. Those values still round-trip, but they go out as a tag 1 float64 rather than the compact integer the original pure-Python encoder always produced for whole-second timestamps. I spotted it while diffing the Rust output against the historical implementation, where `datetime(1969, 12, 31, tzinfo=utc)` came back as `c1fb...` instead of a negint.

Widening the cast to `i64` restores the integer path across the whole representable datetime range, negative timestamps included, while the existing `timestamp_int as f64 == timestamp_float` guard still falls back to a float when there are sub-second microseconds. The decision belongs here in the encoder because it is what shapes the wire form. Left as is it emits non-canonical, larger output and silently disagrees with every other cbor2 release for any timestamp outside a 136-year window.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
