### PR TITLE
reject non-byte-string payloads in bignum decoders

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the decoder accepting a non-byte-string payload for a positive or negative bignum (tags 2
+  and 3). ``int.from_bytes()`` also accepts an array (or a map, whose keys it iterates), so a tag
+  wrapping one of those was coerced into an integer instead of being rejected as malformed
+  (`#326 <https://github.com/agronholm/cbor2/pull/326>`_; PR by @sahvx655-wq)
+
 **6.1.3** (2026-07-04)
 
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -138,6 +138,18 @@ fn require_tuple<'py>(value: Bound<'py, PyAny>, length: usize) -> PyResult<Bound
     Ok(array)
 }
 
+fn require_bignum_bytes(value: Bound<'_, PyAny>) -> PyResult<Bound<'_, PyBytes>> {
+    // Tags 2 and 3 enclose a byte string (RFC 8949 section 3.4.3). int.from_bytes() also
+    // accepts any iterable of ints, so without this guard a tag 2/3 wrapping an array (or a map,
+    // whose keys get iterated) would be coerced into an integer instead of rejected as malformed.
+    let value_type = value.get_type();
+    value.cast_into().map_err(|_| {
+        CBORDecodeError::new_err(format!(
+            "bignum value must be a byte string, not {value_type}"
+        ))
+    })
+}
+
 /// The CBORDecoder class implements a fully featured `CBOR`_ decoder with
 /// several extensions for handling shared references, big integers, rational
 /// numbers and so on. Typically, the class is not used directly, but the
@@ -1064,16 +1076,20 @@ impl CBORDecoder {
     fn decode_positive_bignum(value: Bound<PyAny>, _immutable: bool) -> PyResult<DecoderResult> {
         // Semantic tag 2
         let py = value.py();
+        let payload = require_bignum_bytes(value)?;
         INT_FROMBYTES
             .get(py)?
-            .call1((value, intern!(py, "big")))
+            .call1((payload, intern!(py, "big")))
             .map(CompleteFrame)
     }
 
     fn decode_negative_bignum(value: Bound<PyAny>, _immutable: bool) -> PyResult<DecoderResult> {
         // Semantic tag 3
         let py = value.py();
-        let int = INT_FROMBYTES.get(py)?.call1((value, intern!(py, "big")))?;
+        let payload = require_bignum_bytes(value)?;
+        let int = INT_FROMBYTES
+            .get(py)?
+            .call1((payload, intern!(py, "big")))?;
         int.neg()?.add(-1).map(CompleteFrame)
     }
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -751,7 +751,7 @@ def test_bignum_non_bytestring(payload: str, typename: str) -> None:
     # map, whose keys it iterates), so these malformed payloads must be rejected, not coerced.
     with pytest.raises(
         CBORDecodeError,
-        match=f"error decoding {typename} bignum: bignum value must be a byte string",
+        match=f"error decoding {typename} bignum: bignum value must be a byte string, not int",
     ):
         loads(unhexlify(payload))
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -751,7 +751,7 @@ def test_bignum_non_bytestring(payload: str, typename: str) -> None:
     # map, whose keys it iterates), so these malformed payloads must be rejected, not coerced.
     with pytest.raises(
         CBORDecodeError,
-        match=f"error decoding {typename} bignum: bignum value must be a byte string, not int",
+        match=f"error decoding {typename} bignum: bignum value must be a byte string, not <class ",
     ):
         loads(unhexlify(payload))
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -721,6 +721,25 @@ def test_negative_bignum() -> None:
     assert decoded == -18446744073709551617
 
 
+@pytest.mark.parametrize(
+    "payload, typename",
+    [
+        pytest.param("c28105", "positive", id="positive_array"),
+        pytest.param("c2a10509", "positive", id="positive_map"),
+        pytest.param("c38100", "negative", id="negative_array"),
+        pytest.param("c3a10509", "negative", id="negative_map"),
+    ],
+)
+def test_bignum_non_bytestring(payload: str, typename: str) -> None:
+    # Tags 2 and 3 must enclose a byte string; int.from_bytes() also accepts an array (or a
+    # map, whose keys it iterates), so these malformed payloads must be rejected, not coerced.
+    with pytest.raises(
+        CBORDecodeError,
+        match=f"error decoding {typename} bignum: bignum value must be a byte string",
+    ):
+        loads(unhexlify(payload))
+
+
 def test_fraction() -> None:
     decoded = loads(unhexlify("c48221196ab3"))
     assert decoded == Decimal("273.15")


### PR DESCRIPTION
## Changes

Decoding a tag 2 or tag 3 item runs the payload straight through `int.from_bytes(value, "big")`, but that method accepts any iterable of ints, not only a byte string. While diffing the decoder's output against the pure-Python implementation I noticed that a bignum wrapping an array such as `c28105` came back as the integer `5` instead of raising, and one wrapping a map like `c2a10509` also decoded to `5` because `int.from_bytes` iterates the mapping's keys. RFC 8949 section 3.4.3 says both tags enclose a byte string, and the pure-Python decoder guards this with an `isinstance(value, bytes)` check that the Rust port dropped.

The root cause is that missing type check, and the risk if left is malleability: several distinct encodings decode to the same integer, so a consumer that relies on the decoder to reject malformed CBOR (canonical or deterministic use, deduplication by encoded bytes) quietly accepts ambiguous input. I've added a small `require_bignum_bytes` helper that casts the payload to `bytes` and raises `CBORDecodeError` otherwise, wired into both sibling decoders so the fix stays next to where the value is consumed. A valid byte-string bignum, including the empty byte string that decodes to `0`/`-1`, is unaffected.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
