### PR TITLE
Decode self-describe and unhandled tag containers as mutable

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   current "immutable" status of the decoder stack (i.e. when decoding a map key, immutable would
   be set to ``true``) instead of always decoding as immutable
   (`#295 <https://github.com/agronholm/cbor2/issues/295>`_)
+- **BACKWARD INCOMPATIBLE** Changed the content of the self-describe tag (55799) to be decoded
+  according to the current "immutable" status of the decoder stack instead of always decoding as
+  immutable, so a wrapped map or array now decodes as a ``dict`` or ``list`` again
+  (`#327 <https://github.com/agronholm/cbor2/pull/327>`_; PR by @sahvx655-wq)
 
 **6.1.3** (2026-07-04)
 

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -915,10 +915,17 @@ impl CBORDecoder {
             261 => (Box::new(Self::decode_ipnetwork), "IP network"),
             1004 => (Box::new(Self::decode_date_string), "string-form date"),
             43000 => (Box::new(Self::decode_complex), "complex number"),
-            55799 => (
-                Box::new(Self::decode_self_describe_cbor),
-                "self-described CBOR value",
-            ),
+            55799 => {
+                // The self-describe tag is transparent: its content must decode exactly as it
+                // would without the tag, so it inherits the ambient immutability instead of
+                // forcing the value immutable like the value-consuming tags above.
+                return Ok(BeginFrame(
+                    Box::new(Self::decode_self_describe_cbor),
+                    immutable,
+                    None,
+                    DisplayName::String("self-described CBOR value"),
+                ));
+            }
             _ => {
                 // For a tag with no designated decoder, check if we have a tag hook, and call
                 // that with the tag object, using its return value as the decoded value.

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1062,6 +1062,16 @@ def test_self_describe_cbor(payload: str, expected: object) -> None:
     assert loads(unhexlify(payload)) == expected
 
 
+def test_self_describe_cbor_container_mutable() -> None:
+    """
+    Test that the self-describe tag (55799) is transparent, so a wrapped map or array decodes
+    to a mutable dict or list, exactly as it would without the tag.
+
+    """
+    assert type(loads(unhexlify("d9d9f7a10102"))) is dict
+    assert type(loads(unhexlify("d9d9f7820102"))) is list
+
+
 def test_unhandled_tag() -> None:
     """
     Test that a tag is simply ignored and its associated value returned if there is no special


### PR DESCRIPTION
## Changes

The self-describe tag (55799) arm in `decode_semantic` opens its content with a frame that forces immutable decoding, so a map or array behind the tag comes back as a `frozendict` or `tuple` where the reference pure-Python decoder returns a `dict` or `list`. I found it while diffing decode output against the old pure-Python decoder; the visible effect is a surprise `TypeError` on decode-then-mutate, or a failing `type(x) is list` check, but only when a producer prepends the self-describe magic number.

The tag is transparent per RFC 8949, so the arm now returns its own frame inheriting the ambient immutability, the same way the unknown-tag arm does on this branch since #312. A tag in an immutable position such as a map key still yields a hashable value, and the tuple-consuming tags (fraction, bigfloat, rational, complex, the IPv4/IPv6 array forms) keep their forced-immutable path untouched.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
