### PR TITLE
Encode subclasses of the specially handled types instead of rejecting them

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,14 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the encoder rejecting subclasses of the specially handled types (``datetime``,
+  ``Decimal``, ``UUID``, the ``ipaddress`` types, etc.) with ``CBOREncodeError``; the Rust
+  rewrite matched these types by exact identity where cbor2 5.x used ``issubclass()``, so
+  values like ``pandas.Timestamp`` could no longer be encoded
+  (`#329 <https://github.com/agronholm/cbor2/pull/329>`_; PR by @gaoflow)
+
 **6.1.3** (2026-07-04)
 
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -583,6 +583,13 @@ impl CBOREncoder {
                         ),
                         (
                             py.import("ipaddress")?
+                                .getattr("IPv4Interface")?
+                                .cast_into()?
+                                .unbind(),
+                            CBOREncoder::encode_ipv4_interface,
+                        ),
+                        (
+                            py.import("ipaddress")?
                                 .getattr("IPv4Address")?
                                 .cast_into()?
                                 .unbind(),
@@ -597,10 +604,10 @@ impl CBOREncoder {
                         ),
                         (
                             py.import("ipaddress")?
-                                .getattr("IPv4Interface")?
+                                .getattr("IPv6Interface")?
                                 .cast_into()?
                                 .unbind(),
-                            CBOREncoder::encode_ipv4_interface,
+                            CBOREncoder::encode_ipv6_interface,
                         ),
                         (
                             py.import("ipaddress")?
@@ -617,13 +624,6 @@ impl CBOREncoder {
                             CBOREncoder::encode_ipv6_network,
                         ),
                         (
-                            py.import("ipaddress")?
-                                .getattr("IPv6Interface")?
-                                .cast_into()?
-                                .unbind(),
-                            CBOREncoder::encode_ipv6_interface,
-                        ),
-                        (
                             py.import("email.mime.text")?
                                 .getattr("MIMEText")?
                                 .cast_into()?
@@ -632,8 +632,18 @@ impl CBOREncoder {
                         ),
                     ])
                 })?;
+            // Exact type matches first: the common case, using cheap pointer comparisons
             for (pytype, callback) in stdlib_encoders {
                 if obj_type.is(pytype) {
+                    return callback(slf, obj);
+                }
+            }
+
+            // Fall back to isinstance matching so subclasses encode like their base type,
+            // as they did in cbor2 <= 5.x. The list is ordered so that subclasses precede
+            // their bases (datetime before date, IP interfaces before IP addresses).
+            for (pytype, callback) in stdlib_encoders {
+                if obj.is_instance(pytype.bind(py))? {
                     return callback(slf, obj);
                 }
             }

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -436,6 +436,116 @@ def test_ipaddress(value: object, expected: str) -> None:
     assert dumps(value) == unhexlify(expected)
 
 
+class _DatetimeSubclass(datetime):
+    pass
+
+
+class _DateSubclass(date):
+    pass
+
+
+class _DecimalSubclass(Decimal):
+    pass
+
+
+class _FractionSubclass(Fraction):
+    pass
+
+
+class _UUIDSubclass(UUID):
+    pass
+
+
+class _IPv4AddressSubclass(IPv4Address):
+    pass
+
+
+class _IPv4NetworkSubclass(IPv4Network):
+    pass
+
+
+class _IPv4InterfaceSubclass(IPv4Interface):
+    pass
+
+
+class _IPv6AddressSubclass(IPv6Address):
+    pass
+
+
+class _IPv6NetworkSubclass(IPv6Network):
+    pass
+
+
+class _IPv6InterfaceSubclass(IPv6Interface):
+    pass
+
+
+class _MIMETextSubclass(MIMEText):
+    pass
+
+
+@pytest.mark.parametrize("canonical", [False, True])
+@pytest.mark.parametrize(
+    "subclass_value, base_value",
+    [
+        pytest.param(
+            _DatetimeSubclass(2013, 3, 21, 20, 4, 0, tzinfo=timezone.utc),
+            datetime(2013, 3, 21, 20, 4, 0, tzinfo=timezone.utc),
+            id="datetime",
+        ),
+        pytest.param(_DateSubclass(2013, 3, 21), date(2013, 3, 21), id="date"),
+        pytest.param(_DecimalSubclass("14.123"), Decimal("14.123"), id="decimal"),
+        pytest.param(_FractionSubclass(2, 5), Fraction(2, 5), id="fraction"),
+        pytest.param(
+            _UUIDSubclass(hex="5eaffac8b51e480581277fdcc7842faf"),
+            UUID(hex="5eaffac8b51e480581277fdcc7842faf"),
+            id="uuid",
+        ),
+        pytest.param(_IPv4AddressSubclass("192.0.2.1"), IPv4Address("192.0.2.1"), id="ipv4addr"),
+        pytest.param(
+            _IPv4NetworkSubclass("192.0.2.0/24"), IPv4Network("192.0.2.0/24"), id="ipv4net"
+        ),
+        pytest.param(
+            _IPv4InterfaceSubclass("192.0.2.1/24"), IPv4Interface("192.0.2.1/24"), id="ipv4if"
+        ),
+        pytest.param(
+            _IPv6AddressSubclass("2001:db8::1"), IPv6Address("2001:db8::1"), id="ipv6addr"
+        ),
+        pytest.param(
+            _IPv6NetworkSubclass("2001:db8:1234::/48"),
+            IPv6Network("2001:db8:1234::/48"),
+            id="ipv6net",
+        ),
+        pytest.param(
+            _IPv6InterfaceSubclass("2001:db8::5/64"),
+            IPv6Interface("2001:db8::5/64"),
+            id="ipv6if",
+        ),
+    ],
+)
+def test_stdlib_type_subclass(subclass_value: Any, base_value: Any, canonical: bool) -> None:
+    """Subclasses of the supported stdlib types must encode exactly like the base type."""
+    encoded = dumps(subclass_value, canonical=canonical)
+    assert encoded == dumps(base_value, canonical=canonical)
+    assert loads(encoded) == base_value
+
+
+def test_datetime_subclass_as_timestamp() -> None:
+    value = _DatetimeSubclass(2013, 3, 21, 20, 4, 0, tzinfo=timezone.utc)
+    assert dumps(value, datetime_as_timestamp=True) == unhexlify("c11a514b67b0")
+
+
+def test_date_subclass_as_datetime() -> None:
+    expected = unhexlify("c074323031332d30332d32315430303a30303a30305a")
+    value = _DateSubclass(2013, 3, 21)
+    assert dumps(value, timezone=timezone.utc, date_as_datetime=True) == expected
+
+
+def test_mime_subclass() -> None:
+    message = _MIMETextSubclass("Hello \u20acuro", "plain", "iso-8859-15")
+    assert dumps(message) == dumps(MIMEText("Hello \u20acuro", "plain", "iso-8859-15"))
+
+
 def test_custom_tag() -> None:
     expected = unhexlify("d917706548656c6c6f")
     assert dumps(CBORTag(6000, "Hello")) == expected


### PR DESCRIPTION
## Changes

Since the Rust rewrite, encoding a subclass of any of the specially handled types raises `CBOREncodeError`:

```python
>>> import cbor2, datetime
>>> class MyDatetime(datetime.datetime): pass
>>> cbor2.dumps(MyDatetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
cbor2.CBOREncodeError: cannot encode type <class '__main__.MyDatetime'>
```

cbor2 5.x encoded these like their base type (verified on 5.9.0, both the C extension and the pure-Python implementation — `_find_encoder` used `issubclass()`), so things like `pandas.Timestamp` or `Decimal`/`UUID` subclasses used to work. It's also inconsistent with the primitives, whose subclasses (`int`, `str`, `bytes`, ...) still encode fine in 6.x. The 6.0 changelog doesn't list this among the backward-incompatible changes, so I'm assuming it's unintended.

The fix keeps the exact-identity pass over the stdlib encoder table first, so the common case still only pays pointer comparisons, and adds an `isinstance()` fallback pass for subclasses. The table is reordered so subclasses precede their bases in that fallback (`IPv4Interface`/`IPv6Interface` before the address types, like `datetime` before `date`) — so an interface subclass is encoded as an interface, not silently downgraded to a bare address the way 5.x did it.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
