### PR TITLE
reject indefinite-length maps missing a value for the last key

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the decoder silently accepting an indefinite-length map whose break marker arrives after a
+  key with no value, dropping that trailing key and returning a truncated map instead of rejecting
+  the ill-formed input
+  (`#331 <https://github.com/agronholm/cbor2/pull/331>`_; PR by @sahvx655-wq)
+
 **6.1.3** (2026-07-04)
 
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -729,6 +729,11 @@ impl CBORDecoder {
                 let break_marker = BREAK_MARKER.get(py).unwrap().bind(py);
                 Box::new(move |item: Bound<'py, PyAny>, _immutable: bool| {
                     if item.is(break_marker) {
+                        if key.is_some() {
+                            return Err(CBORDecodeError::new_err(
+                                "missing value for key in indefinite-length map",
+                            ));
+                        }
                         let container = create_frozen_dict(py, take(&mut items))?;
                         let transformed = maybe_call_object_hook(
                             py,
@@ -793,6 +798,11 @@ impl CBORDecoder {
                 let break_marker = BREAK_MARKER.get(py).unwrap().bind(py);
                 Box::new(move |item: Bound<'py, PyAny>, _immutable: bool| {
                     if item.is(break_marker) {
+                        if key.is_some() {
+                            return Err(CBORDecodeError::new_err(
+                                "missing value for key in indefinite-length map",
+                            ));
+                        }
                         let dict = replace(&mut dict, PyDict::new(py));
                         let transformed = maybe_call_object_hook(
                             py,

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -533,6 +533,22 @@ def test_bad_streaming_strings(payload: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("bf6161ff", id="mutable"),
+        pytest.param("bf6161016162ff", id="mutable/after-pair"),
+        pytest.param("d9010281bf6161016162ff", id="immutable"),
+    ],
+)
+def test_indefinite_map_missing_value(payload: str) -> None:
+    with pytest.raises(
+        CBORDecodeError,
+        match="missing value for key in indefinite-length map",
+    ):
+        loads(unhexlify(payload))
+
+
+@pytest.mark.parametrize(
     "payload, value",
     [
         ("e0", 0),


### PR DESCRIPTION
## Changes

An indefinite-length map is assembled in `decode_map` by taking each decoded item and alternately stashing it as a pending key or pairing it with the previously stashed key. The trouble is the break marker: when it arrives while a key is still pending (an odd number of data items before the stop code), the closure takes the `item.is(break_marker)` branch and completes the frame regardless, so the pending key is quietly dropped and a truncated map comes back. `loads(unhexlify("bf6161016162ff"))` returns `{"a": 1}` with the trailing `"b"` gone, and `bf6161ff` returns `{}`. Both the mutable dict path and the immutable frozendict path carry the same defect. RFC 8949 requires an indefinite-length map to be complete key/value pairs, so a break after a key is ill-formed and must fault; the pure-Python decoder rejects these payloads with a decode error. Left unfixed the decoder silently accepts malformed input and hands back a map that never existed on the wire, which is the sort of divergence that bites anyone comparing two decoders or relying on strict framing.

The break branch now checks for a pending key first and raises `CBORDecodeError` before completing, at both indefinite-map sites. Keeping the guard where the pairing state lives means the definite-length paths, the duplicate-key handling and the object hook are all untouched, and a well-formed indefinite map still decodes exactly as before.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).