### PR TITLE
register bytearrays in the string reference namespace

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,14 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the encoder not registering :class:`bytearray` values in the string reference namespace,
+  unlike :class:`bytes` and :class:`str`; since the decoder registers every byte string it reads, a
+  single ``bytearray`` desynchronised the namespace and made subsequent string references resolve
+  to the wrong value
+  (`#332 <https://github.com/agronholm/cbor2/pull/332>`_; PR by @sahvx655-wq)
+
 **6.1.3** (2026-07-04)
 
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -793,9 +793,18 @@ impl CBOREncoder {
 
     fn encode_bytearray(slf: &Bound<'_, Self>, obj: &Bound<'_, PyByteArray>) -> PyResult<()> {
         let py = slf.py();
+        let string_referencing = slf.borrow().string_referencing;
+        let bytes = obj.to_vec();
+
+        // A bytearray is written out as a byte string, so it shares the string reference
+        // namespace with bytes objects
+        if string_referencing && Self::maybe_stringref(slf, PyBytes::new(py, &bytes).as_any())? {
+            return Ok(());
+        }
+
         let mut this = slf.borrow_mut();
-        this.encode_length(py, 2, Some(obj.len() as u64))?;
-        this.write_internal(py, obj.to_vec())
+        this.encode_length(py, 2, Some(bytes.len() as u64))?;
+        this.write_internal(py, bytes)
     }
 
     fn encode_array(slf: &Bound<'_, Self>, obj: &Bound<'_, PySequence>) -> PyResult<()> {

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -699,6 +699,24 @@ def test_encode_stringrefs_non_ascii() -> None:
     assert loads(encoded) == value
 
 
+def test_encode_stringrefs_bytearray() -> None:
+    # A bytearray goes on the wire as a plain byte string, so the decoder registers it in
+    # the namespace and the encoder has to occupy the same index (0 here)
+    value = [bytearray(b"abcd"), "efgh", "efgh"]
+    encoded = dumps(value, string_referencing=True)
+    expected = unhexlify("d901008344616263646465666768d81901")
+    assert encoded == expected
+    assert loads(encoded) == [b"abcd", "efgh", "efgh"]
+
+
+def test_encode_stringrefs_repeated_bytearray() -> None:
+    value = [bytearray(b"abcd"), bytearray(b"abcd"), b"abcd"]
+    encoded = dumps(value, string_referencing=True)
+    expected = unhexlify("d90100834461626364d81900d81900")
+    assert encoded == expected
+    assert loads(encoded) == [b"abcd", b"abcd", b"abcd"]
+
+
 @pytest.mark.parametrize(
     "tag",
     [


### PR DESCRIPTION
## Changes

`encode_bytearray` writes its payload as a plain CBOR byte string (major type 2), but unlike `encode_bytes` and `encode_string` it never calls `maybe_stringref`, so the value is neither emitted as a tag 25 reference when it repeats nor registered in the namespace. I found this while sweeping every major type 2/3 write site after #314, lining each encoder up against what the decoder registers on the way back in. The decoder registers every byte string it reads, so one `bytearray` of registrable length is enough to desynchronise its indices from the encoder's: `dumps([bytearray(b"abcd"), "efgh", "efgh"], string_referencing=True)` emits `d81900` for the repeated `"efgh"`, and `loads()` hands back `[b"abcd", "efgh", b"abcd"]`.

The root cause is the missing registration call rather than anything in the threshold logic #313 and #314 dealt with, so the fix routes `encode_bytearray` through `maybe_stringref` on a `PyBytes` view of the buffer, keeping the decision in the helper the other two encoders already share. What makes it worth fixing is that nothing faults on the way through: no warning, no decode error, just an unrelated earlier value substituted into the result, which is the hardest sort of corruption to trace back from the far end. A `bytearray` and a `bytes` object with the same contents now produce identical output, and `string_referencing=False` is untouched. `encode_bytearray` was the only remaining site: `memoryview` is unaffected because it encodes as an array of integers rather than a byte string.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
