### PR TITLE
hash frozendict by its items instead of keys and values separately

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,14 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed :class:`frozendict` deriving its hash from its keys and its values as two independent
+  sets, so that frozendicts holding the same keys and the same values all collided regardless of
+  how the two were paired; since the decoder builds a frozendict for every map in an immutable
+  position, a payload keyed by such maps decoded in quadratic time
+  (`#333 <https://github.com/agronholm/cbor2/pull/333>`_; PR by @sahvx655-wq)
+
 **6.1.3** (2026-07-04)
 
 - Fixed the decoder registering 6-byte strings in the string reference namespace at indices

--- a/rust/types.rs
+++ b/rust/types.rs
@@ -337,11 +337,11 @@ impl FrozenDict {
 
     fn __hash__(&mut self, py: Python<'_>) -> PyResult<u64> {
         if (self.hash).is_none() {
-            let keys_hash = PyFrozenSet::new(py, self.dict.bind(py).keys())?.hash()?;
-            let values_hash = PyFrozenSet::new(py, self.dict.bind(py).values())?.hash()?;
+            // Hash the items rather than the keys and values separately, so that the pairing
+            // between them contributes to the hash
+            let items_hash = PyFrozenSet::new(py, self.dict.bind(py).items())?.hash()?;
             let mut hasher = DefaultHasher::new();
-            hasher.write_isize(keys_hash);
-            hasher.write_isize(values_hash);
+            hasher.write_isize(items_hash);
             self.hash = Some(hasher.finish());
         }
         Ok(self.hash.unwrap())

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -131,6 +131,13 @@ class TestFrozendict:
         assert obj[1] == 2
         assert hash(obj) == obj_hash
 
+    def test_hash_depends_on_pairing(self) -> None:
+        obj1 = frozendict[int, int]({1: 1, 2: 2})
+        obj2 = frozendict[int, int]({1: 2, 2: 1})
+        assert obj1 != obj2
+        assert hash(obj1) != hash(obj2)
+        assert hash(obj1) == hash(frozendict[int, int]({2: 2, 1: 1}))
+
     def test_items(self) -> None:
         obj = frozendict[int, int]({1: 2, 3: 4})
         items = obj.items()


### PR DESCRIPTION
## Changes

`FrozenDict::__hash__` builds two frozensets, one over the keys and one over the values, hashes each and mixes the two results, so the pairing between a key and its value never reaches the hash at all. Every bijection of one key set onto one value set consequently lands on a single hash: `frozendict({1: 1, 2: 2})` and `frozendict({1: 2, 2: 1})` are unequal but hash identically, and given k distinct keys and k distinct values, all k! arrangements collide. I went looking after a decode of nested maps ran far slower than the payload size suggested, and it is the decoder that makes this reachable from input, since it hands back a frozendict for every map decoded in an immutable position (map keys, set members, tag payloads, `immutable=True`). A 116 KiB payload whose outer map is keyed by 5040 such maps spends 8.7 s in `loads()` against 0.045 s for an equally sized payload whose keys hash distinctly, and the cost is quadratic in the key count, so it degrades sharply from there. Left alone that is a cheap way to burn CPU in anything decoding untrusted CBOR, and it quietly penalises every legitimate dict or set holding decoded maps too.

Hashing the frozenset of the mapping's items folds the pairing back in; the same payload now decodes in 0.022 s, in line with the non-colliding control. Hashability requirements do not move, because a `(key, value)` tuple is hashable exactly when both halves are, and equal frozendicts still hash equal since equal mappings have equal item sets, so there is no behavioural change for valid input beyond the hash value itself. This sits in `__hash__` rather than in the decoder because the decoder is only one caller: `frozendict` is public API, and anything placing one into a dict or set meets the same collisions.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
