### PR TITLE
Hash CBORSimpleValue consistently with its integer value

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to, so
-  that ``CBORSimpleValue(n) == n`` held while ``hash(CBORSimpleValue(n)) != hash(n)``. A decoded
-  simple value could not be looked up by its integer in a mapping or set, and an integer key
-  colliding with a simple-value key slipped past the ``allow_duplicate_keys=False`` check
+- Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 
 **6.1.4** (2026-08-01)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,14 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to, so
+  that ``CBORSimpleValue(n) == n`` held while ``hash(CBORSimpleValue(n)) != hash(n)``. A decoded
+  simple value could not be looked up by its integer in a mapping or set, and an integer key
+  colliding with a simple-value key slipped past the ``allow_duplicate_keys=False`` check
+  (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
+
 **6.1.4** (2026-08-01)
 
 - Fixed :class:`frozendict` deriving its hash from its keys and its values as two independent

--- a/rust/types.rs
+++ b/rust/types.rs
@@ -197,10 +197,11 @@ impl CBORSimpleValue {
         format!("CBORSimpleValue({})", self.0)
     }
 
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.0.hash(&mut hasher);
-        hasher.finish()
+    fn __hash__(&self, py: Python<'_>) -> PyResult<isize> {
+        // __richcmp__ treats CBORSimpleValue(n) as equal to the integer n, so the hash has to
+        // agree with that of the integer, otherwise the two are not interchangeable as mapping
+        // keys or set members.
+        self.0.into_bound_py_any(py)?.hash()
     }
 }
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -202,6 +202,13 @@ class TestAllowDuplicateKeys:
         with pytest.raises(CBORDecodeError, match="Duplicate map key: 'a'"):
             loads(unhexlify(payload), allow_duplicate_keys=False, immutable=immutable)
 
+    @pytest.mark.parametrize("immutable", [False, True])
+    def test_raises_on_duplicate_int_and_simple_value(self, immutable: bool) -> None:
+        # {5: 1, simple(5): 2}: the integer 5 and simple value 5 compare equal, so this is a
+        # duplicate key and must be rejected rather than kept as two distinct entries
+        with pytest.raises(CBORDecodeError, match="Duplicate map key"):
+            loads(unhexlify("a20501e502"), allow_duplicate_keys=False, immutable=immutable)
+
 
 def test_readonly_attributes() -> None:
     decoder = CBORDecoder(BytesIO())

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -108,6 +108,14 @@ class TestCBORSimpleValue:
     def test_repr(self) -> None:
         assert repr(CBORSimpleValue(1)) == "CBORSimpleValue(1)"
 
+    def test_hash_matches_int(self) -> None:
+        # CBORSimpleValue(n) compares equal to the int n, so it must also hash like n,
+        # otherwise the two are not interchangeable as mapping keys or set members
+        assert hash(CBORSimpleValue(5)) == hash(5)
+        assert {5: "x"}[CBORSimpleValue(5)] == "x"
+        assert {CBORSimpleValue(5): "x"}[5] == "x"
+        assert len({5, CBORSimpleValue(5)}) == 1
+
 
 class TestFrozendict:
     def test_from_dict(self) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -112,8 +112,10 @@ class TestCBORSimpleValue:
         # CBORSimpleValue(n) compares equal to the int n, so it must also hash like n,
         # otherwise the two are not interchangeable as mapping keys or set members
         assert hash(CBORSimpleValue(5)) == hash(5)
-        assert {5: "x"}[CBORSimpleValue(5)] == "x"
-        assert {CBORSimpleValue(5): "x"}[5] == "x"
+        mapping: dict[int | CBORSimpleValue, str] = {5: "x"}
+        assert mapping[CBORSimpleValue(5)] == "x"
+        mapping = {CBORSimpleValue(5): "x"}
+        assert mapping[5] == "x"
         assert len({5, CBORSimpleValue(5)}) == 1
 
 


### PR DESCRIPTION
1. `__richcmp__` treats `CBORSimpleValue(n)` as equal to the integer `n`, but `__hash__` ran the raw byte through a Rust `DefaultHasher`, so equal values hashed differently and broke Python's rule that equal objects hash alike.
2. As a result a decoded simple value could not be found by its integer in a dict or set, and under `allow_duplicate_keys=False` a map carrying both `5` and simple value `5` was accepted rather than rejected as a duplicate, since the two landed in different hash buckets.
3. Restored `__hash__` to return the hash of the underlying integer, matching the comparison semantics and the behaviour of the pure-Python decoder this port replaced.

I noticed this while auditing the `__hash__` implementations in `types.rs`: the comparison operators fall back to comparing against a plain `int`, which only makes sense if the hashes line up too. Regression tests for the key interchangeability and for the duplicate-key check are included.
