### PR TITLE
Document decoding concatenated CBOR objects

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,44 @@ Serializing and deserializing with cbor2 is pretty straightforward::
 
 Some data types, however, require extra considerations, as detailed below.
 
+Decoding a sequence of objects
+------------------------------
+
+A file can contain several CBOR objects concatenated together, without an enclosing array.
+Call :meth:`CBORDecoder.decode` once for each object. Check for the end of the file *between*
+objects, rather than catching :exc:`CBORDecodeEOF`: that exception can also mean that the
+last object is incomplete.
+
+For a binary file opened with the default buffering, use its :meth:`~io.BufferedReader.peek`
+method to check whether another object starts next:
+
+>>> from cbor2 import CBORDecoder
+>>> def iter_cbor_sequence(fp):
+...     decoder = CBORDecoder(fp)
+...     while fp.peek(1):
+...         yield decoder.decode()
+
+Use it to read the objects one at a time::
+
+    with open("input.cbor", "rb") as fp:
+        for obj in iter_cbor_sequence(fp):
+            print(obj)
+
+The decoder leaves the file positioned after the decoded object, including when it reads ahead
+internally. ``peek(1)`` does not consume the next byte. An empty file therefore produces no
+objects, while an incomplete or invalid object raises a decoding exception instead of silently
+ending iteration. This example requires a buffered binary reader with ``peek()``; a bare
+:class:`~io.BytesIO` does not provide that method. Wrap it in :class:`~io.BufferedReader`:
+
+>>> from io import BufferedReader, BytesIO
+>>> from cbor2 import dumps
+>>> data = dumps([1, 2]) + dumps({"name": "example"})
+>>> with BufferedReader(BytesIO(data)) as fp:
+...     list(iter_cbor_sequence(fp))
+[[1, 2], {'name': 'example'}]
+
+For command-line conversion to JSON, use ``cbor2 --sequence input.cbor``.
+
 Date/time handling
 ------------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Documented how to decode concatenated CBOR objects without hiding truncated input
+  (`#30 <https://github.com/agronholm/cbor2/issues/30>`_; PR by @be-student)
+
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 

--- a/tests/test_sequence_documentation.py
+++ b/tests/test_sequence_documentation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import doctest
+from collections.abc import Callable, Iterator
+from io import BufferedReader, BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from cbor2 import CBORDecodeEOF, CBORDecodeError, dumps
+
+
+@pytest.fixture
+def read_sequence() -> Callable[[BufferedReader[BytesIO]], Iterator[Any]]:
+    path = Path(__file__).parent.parent / "docs" / "usage.rst"
+    test = doctest.DocTestParser().get_doctest(path.read_text(), {}, "usage", str(path), 0)
+    result = doctest.DocTestRunner().run(test, clear_globs=False)
+    assert result.failed == 0
+    assert result.attempted > 0
+    return cast(
+        "Callable[[BufferedReader[BytesIO]], Iterator[Any]]", test.globs["iter_cbor_sequence"]
+    )
+
+
+@pytest.mark.parametrize("size", [0, 1, 4095, 4096, 8193])
+def test_sequence_boundaries(
+    read_sequence: Callable[[BufferedReader[BytesIO]], Iterator[Any]], size: int
+) -> None:
+    objects = [None, "x" * size, {"value": size}, [1, 2]]
+    with BufferedReader(BytesIO(b"".join(dumps(obj) for obj in objects))) as fp:
+        assert list(read_sequence(fp)) == objects
+    with BufferedReader(BytesIO()) as fp:
+        assert list(read_sequence(fp)) == []
+
+
+@pytest.mark.parametrize("suffix", [b"\x18", b"\x63ab", b"\x82\x01"])
+def test_sequence_truncated_object(
+    read_sequence: Callable[[BufferedReader[BytesIO]], Iterator[Any]], suffix: bytes
+) -> None:
+    with BufferedReader(BytesIO(dumps("complete") + suffix)) as fp:
+        objects = read_sequence(fp)
+        assert next(objects) == "complete"
+        with pytest.raises(CBORDecodeEOF):
+            next(objects)
+
+
+def test_sequence_invalid_object(
+    read_sequence: Callable[[BufferedReader[BytesIO]], Iterator[Any]],
+) -> None:
+    with BufferedReader(BytesIO(dumps(1) + b"\x1c")) as fp:
+        objects = read_sequence(fp)
+        assert next(objects) == 1
+        with pytest.raises(CBORDecodeError):
+            next(objects)


### PR DESCRIPTION
## Changes

Fixes #30.

Document a buffered-reader example for concatenated CBOR objects that checks for EOF between objects and lets truncated or malformed objects raise decoding errors. Explain decoder read-ahead, show both file and in-memory usage, and link the CLI sequence option.

The normal pytest suite executes the documented function and examples, then checks empty input, multiple objects across buffer boundaries, and incomplete or invalid final objects. This changes documentation and tests only; it adds no public API or decoder behavior.

## Validation

- Built the current Rust extension with `RUSTFLAGS="--deny warnings"` on macOS/Python 3.12.
- Full pytest suite: 473 passed; focused documentation cases: 9 passed.
- Pre-commit checks passed after formatting, including mypy and cargo fmt.
- Sphinx HTML renders, but `sphinx-build -W -n` reports three unresolved `typing.Union` references. The unchanged HEAD documentation produces the identical three warnings; no new references fail.

## Checklist

- [x] Added tests in `tests/` that execute the new documentation and fail when its examples are absent or incorrect.
- [x] Updated `docs/usage.rst`.
- [x] Added an entry in `docs/versionhistory.rst`.
