### PR TITLE
Add optional mutable byte string decoding

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,19 @@ Serializing and deserializing with cbor2 is pretty straightforward::
 
 Some data types, however, require extra considerations, as detailed below.
 
+Mutable byte strings
+--------------------
+
+By default, CBOR byte strings are decoded as :class:`bytes`. Pass ``mutable_bytes=True`` to
+:func:`load`, :func:`loads` or :class:`CBORDecoder` to decode ordinary byte strings as
+:class:`bytearray` instead::
+
+    mutable_data = loads(b'\x44data', mutable_bytes=True)
+    mutable_data[0] = ord('D')
+
+Byte strings in immutable positions, such as map keys and semantic tag payloads that require
+bytes, remain :class:`bytes`.
+
 Date/time handling
 ------------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ``mutable_bytes`` parameter to :class:`CBORDecoder`, :func:`load` and :func:`loads`,
+  allowing ordinary CBOR byte strings to be decoded as :class:`bytearray`
+  (`#266 <https://github.com/agronholm/cbor2/issues/266>`_; PR by @be-student)
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 

--- a/python/cbor2/__init__.pyi
+++ b/python/cbor2/__init__.pyi
@@ -131,6 +131,7 @@ class CBORDecoder:
         max_depth: int = ...,
         allow_indefinite: bool = ...,
         allow_duplicate_keys: bool = ...,
+        mutable_bytes: bool = ...,
     ) -> Self: ...
 
     # Properties
@@ -142,6 +143,8 @@ class CBORDecoder:
     def allow_indefinite(self) -> bool: ...
     @property
     def allow_duplicate_keys(self) -> bool: ...
+    @property
+    def mutable_bytes(self) -> bool: ...
     def decode(self, *, immutable: bool = ...) -> Any: ...
     def read(self, amount: int, /) -> bytes: ...
 
@@ -222,6 +225,7 @@ def load(
     allow_indefinite: bool = ...,
     allow_duplicate_keys: bool = ...,
     immutable: bool = ...,
+    mutable_bytes: bool = ...,
 ) -> Any: ...
 def loads(
     data: Buffer,
@@ -235,6 +239,7 @@ def loads(
     allow_indefinite: bool = ...,
     allow_duplicate_keys: bool = ...,
     immutable: bool = ...,
+    mutable_bytes: bool = ...,
 ) -> Any: ...
 def shareable_encoder(
     wraps: Callable[[CBOREncoder, _T], None], /

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -15,11 +15,12 @@ use half::f16;
 use pyo3::exceptions::{PyException, PyLookupError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyBytes, PyCFunction, PyComplex, PyDict, PyFrozenSet, PyInt, PyList, PyListMethods, PyMapping,
-    PySet, PyString, PyTuple,
+    PyByteArray, PyBytes, PyCFunction, PyComplex, PyDict, PyFrozenSet, PyInt, PyList,
+    PyListMethods, PyMapping, PySet, PyString, PyTuple,
 };
 use pyo3::{IntoPyObjectExt, Py, PyAny, PyErrArguments, intern, pyclass};
 use std::fmt::{Display, Formatter};
+use std::io::Write;
 use std::mem::{replace, take};
 
 const IMMUTABLE_ATTR: &str = "_cbor2_immutable";
@@ -185,6 +186,8 @@ fn require_bignum_bytes(value: Bound<'_, PyAny>) -> PyResult<Bound<'_, PyBytes>>
 /// :param allow_duplicate_keys:
 ///     if :data:`False`, raise a :exc:`CBORDecodeError` when a map key that has already been
 ///     decoded in the same map is encountered
+/// :param mutable_bytes:
+///     if :data:`True`, decode byte strings as :class:`bytearray` when a mutable value is allowed
 ///
 /// .. _CBOR: https://cbor.io/
 #[pyclass(module = "cbor2")]
@@ -202,6 +205,8 @@ pub struct CBORDecoder {
     allow_indefinite: bool,
     #[pyo3(get)]
     allow_duplicate_keys: bool,
+    #[pyo3(get)]
+    mutable_bytes: bool,
 
     read_method: Option<Py<PyAny>>,
     buffer: Option<Py<PyBytes>>,
@@ -223,6 +228,7 @@ impl CBORDecoder {
         max_depth: usize,
         allow_indefinite: bool,
         allow_duplicate_keys: bool,
+        mutable_bytes: bool,
     ) -> PyResult<Self> {
         let available_bytes = if let Some(buffer) = buffer.as_ref() {
             buffer.len()?
@@ -239,6 +245,7 @@ impl CBORDecoder {
             max_depth,
             allow_indefinite,
             allow_duplicate_keys,
+            mutable_bytes,
             semantic_decoders: semantic_decoders.map(|d| d.clone().unbind()),
             read_method: None,
             buffer: buffer.map(Bound::unbind),
@@ -398,13 +405,15 @@ impl CBORDecoder {
         &mut self,
         py: Python<'py>,
         subtype: u8,
+        immutable: bool,
     ) -> PyResult<DecoderResult<'py>> {
         // Major tag 2
+        let mutable = self.mutable_bytes && !immutable;
         match self.decode_length_as_usize(py, subtype)? {
             None => {
                 // Indefinite length
                 let sys_maxsize = *SYS_MAXSIZE.get(py).unwrap();
-                let bytes = PyBytes::new_with_writer(py, 0, |writer| {
+                let mut read_chunks = |writer: &mut dyn Write| -> PyResult<()> {
                     loop {
                         let (major_type, subtype) = self.read_major_and_subtype(py)?;
                         match (major_type, subtype) {
@@ -415,42 +424,63 @@ impl CBORDecoder {
                                         "chunk too long in an indefinite bytestring chunk: {length}"
                                     )));
                                 }
-                                let length = length as usize;
-                                let chunk = self.read(py, length)?;
+                                let chunk = self.read(py, length as usize)?;
                                 writer.write_all(&chunk)?;
                             }
-                            (7, 31) => break Ok(()), // break marker
+                            (7, 31) => break Ok(()),
                             _ => {
                                 return Err(CBORDecodeError::new_err(format!(
                                     "non-byte string (major type {major_type}) found in indefinite \
-                                    length byte string"
+                                     length byte string"
                                 )));
                             }
                         }
                     }
-                })?;
-                Ok(Value(bytes.into_any()))
+                };
+                if mutable {
+                    let mut bytes = Vec::new();
+                    read_chunks(&mut bytes)?;
+                    Ok(Value(PyByteArray::new(py, &bytes).into_any()))
+                } else {
+                    let bytes = PyBytes::new_with_writer(py, 0, |writer| read_chunks(writer))?;
+                    Ok(Value(bytes.into_any()))
+                }
             }
             Some(length) if length <= 65536 => {
                 let bytes = self.read(py, length)?;
-                Ok(StringValue(PyBytes::new(py, &bytes).into_any(), length))
+                let value = if mutable {
+                    PyByteArray::new(py, &bytes).into_any()
+                } else {
+                    PyBytes::new(py, &bytes).into_any()
+                };
+                Ok(StringValue(value, length))
             }
             Some(length) => {
-                // Incrementally read the bytestring, in chunks of 65536 bytes. The claimed
-                // length is untrusted until the data has actually been read, so no more than
-                // 64 KiB of it is reserved up front; a truncated payload claiming a huge length
-                // can then force at most a 64 KiB allocation.
-                let bytes = PyBytes::new_with_writer(py, length.min(65536), |writer| {
+                // The claimed length is untrusted until all data has been read, so reserve no
+                // more than 64 KiB up front. This avoids allocating the claimed size for a
+                // truncated malicious payload.
+                if mutable {
+                    let mut bytes = Vec::with_capacity(length.min(65536));
                     let mut remaining_length = length;
                     while remaining_length > 0 {
                         let chunk_size = remaining_length.min(65536);
-                        let chunk = self.read(py, chunk_size)?;
+                        bytes.extend_from_slice(&self.read(py, chunk_size)?);
                         remaining_length -= chunk_size;
-                        writer.write_all(&chunk)?;
                     }
-                    Ok(())
-                })?;
-                Ok(StringValue(bytes.into_any(), length))
+                    Ok(StringValue(PyByteArray::new(py, &bytes).into_any(), length))
+                } else {
+                    let bytes = PyBytes::new_with_writer(py, length.min(65536), |writer| {
+                        let mut remaining_length = length;
+                        while remaining_length > 0 {
+                            let chunk_size = remaining_length.min(65536);
+                            let chunk = self.read(py, chunk_size)?;
+                            remaining_length -= chunk_size;
+                            writer.write_all(&chunk)?;
+                        }
+                        Ok(())
+                    })?;
+                    Ok(StringValue(bytes.into_any(), length))
+                }
             }
         }
     }
@@ -1427,6 +1457,7 @@ impl CBORDecoder {
         max_depth = 400,
         allow_indefinite = true,
         allow_duplicate_keys = true,
+        mutable_bytes = false,
     ))]
     pub fn new(
         py: Python<'_>,
@@ -1439,6 +1470,7 @@ impl CBORDecoder {
         max_depth: usize,
         allow_indefinite: bool,
         allow_duplicate_keys: bool,
+        mutable_bytes: bool,
     ) -> PyResult<Self> {
         Self::new_internal(
             py,
@@ -1452,6 +1484,7 @@ impl CBORDecoder {
             max_depth,
             allow_indefinite,
             allow_duplicate_keys,
+            mutable_bytes,
         )
     }
 
@@ -1664,7 +1697,7 @@ impl CBORDecoder {
                 match major_type {
                     0 => self.decode_uint(py, subtype),
                     1 => self.decode_negint(py, subtype),
-                    2 => self.decode_bytestring(py, subtype),
+                    2 => self.decode_bytestring(py, subtype, current_immutable),
                     3 => self.decode_string(py, subtype),
                     4 => self.decode_array(py, subtype, current_immutable),
                     5 => self.decode_map(py, subtype, current_immutable),

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -95,6 +95,9 @@ mod _cbor2 {
     /// :param immutable:
     ///     if :data:`True`, return immutable objects (e.g. :class:`frozenset` and :class:`tuple`)
     ///     instead of mutable objects (e.g. :class:`list` and :class:`dict`)
+    /// :param mutable_bytes:
+    ///     if :data:`True`, decode byte strings as :class:`bytearray` when mutable values are
+    ///     allowed
     /// :return:
     ///     the deserialized object
     ///
@@ -112,6 +115,7 @@ mod _cbor2 {
         allow_indefinite = true,
         allow_duplicate_keys = true,
         immutable = false,
+        mutable_bytes = false,
     ))]
     fn load<'py>(
         py: Python<'py>,
@@ -125,6 +129,7 @@ mod _cbor2 {
         allow_indefinite: bool,
         allow_duplicate_keys: bool,
         immutable: bool,
+        mutable_bytes: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let mut decoder = CBORDecoder::new(
             py,
@@ -137,6 +142,7 @@ mod _cbor2 {
             max_depth,
             allow_indefinite,
             allow_duplicate_keys,
+            mutable_bytes,
         )?;
         decoder.decode(py, immutable)
     }
@@ -175,6 +181,9 @@ mod _cbor2 {
     /// :param immutable:
     ///     if :data:`True`, return immutable objects (e.g. :class:`frozenset` and :class:`tuple`)
     ///     instead of mutable objects (e.g. :class:`list` and :class:`dict`)
+    /// :param mutable_bytes:
+    ///     if :data:`True`, decode byte strings as :class:`bytearray` when mutable values are
+    ///     allowed
     /// :return:
     ///     the deserialized object
     ///
@@ -191,6 +200,7 @@ mod _cbor2 {
         allow_indefinite = true,
         allow_duplicate_keys = true,
         immutable = false,
+        mutable_bytes = false,
     ))]
     fn loads<'py>(
         py: Python<'py>,
@@ -203,6 +213,7 @@ mod _cbor2 {
         allow_indefinite: bool,
         allow_duplicate_keys: bool,
         immutable: bool,
+        mutable_bytes: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let bytes = if let Ok(bytes) = data.cast::<PyBytes>() {
             bytes.clone()
@@ -229,6 +240,7 @@ mod _cbor2 {
             max_depth,
             allow_indefinite,
             allow_duplicate_keys,
+            mutable_bytes,
         )?;
         decoder.decode(py, immutable)
     }

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -442,6 +442,49 @@ def test_indefinite_bytestring_many_chunks() -> None:
     assert result == b"\x2a" * count
 
 
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        (b"\x44data", b"data"),
+        (b"\x5f\x42da\x42ta\xff", b"data"),
+        (b"\x5a\x00\x01\x00\x01" + b"x" * 65537, b"x" * 65537),
+    ],
+    ids=("short", "indefinite", "large"),
+)
+def test_mutable_bytestrings(payload: bytes, expected: bytes) -> None:
+    result = loads(payload, mutable_bytes=True)
+
+    assert isinstance(result, bytearray)
+    assert result == expected
+    result[0] = ord("X")
+    assert result[0] == ord("X")
+
+
+def test_mutable_bytestrings_default_to_bytes() -> None:
+    assert isinstance(loads(b"\x44data"), bytes)
+    assert isinstance(loads(b"\x44data", mutable_bytes=True, immutable=True), bytes)
+
+
+def test_mutable_bytestring_map_keys_remain_hashable() -> None:
+    result = loads(b"\xa1\x41k\x41v", mutable_bytes=True)
+
+    key = next(iter(result))
+    assert isinstance(key, bytes)
+    assert isinstance(result[key], bytearray)
+
+
+def test_mutable_bytestrings_supported_by_load_and_decoder() -> None:
+    assert load(BytesIO(b"\x44data"), mutable_bytes=True) == bytearray(b"data")
+
+    decoder = CBORDecoder(BytesIO(b"\x44data"), mutable_bytes=True)
+    assert decoder.mutable_bytes is True
+    assert decoder.decode() == bytearray(b"data")
+
+
+def test_mutable_bytestrings_preserve_semantic_decoding() -> None:
+    assert loads(b"\xc2\x42\x01\x00", mutable_bytes=True) == 256
+
+
 def test_indefinite_string_many_chunks() -> None:
     # Same quadratic concatenation issue for indefinite-length text strings; the final chunk
     # carries a multi-byte character to exercise the join path.


### PR DESCRIPTION
## Changes

Fixes #266.

Adds `mutable_bytes=True` to `CBORDecoder`, `load()`, and `loads()` so ordinary CBOR byte strings decode as `bytearray`. Immutable contexts such as map keys and semantic tag payloads remain `bytes`.

## Checklist

- [x] Added regression tests
- [x] Updated documentation
- [x] Added a changelog entry
