### PR TITLE
disable value sharing while computing canonical sort keys

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
+- Fixed canonical encoding with value sharing enabled emitting shared references to container
+  keys that were never written to the stream, because the throwaway encoding used to sort the keys
+  registered them as shared values; the output then failed to decode, or decoded with the wrong
+  keys substituted in
+  (`#339 <https://github.com/agronholm/cbor2/pull/339>`_; PR by @sahvx655-wq)
 
 **6.1.4** (2026-08-01)
 

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -705,9 +705,6 @@ impl CBOREncoder {
         slf: &Bound<'py, Self>,
         key: &Bound<'py, PyAny>,
     ) -> PyResult<(usize, Bound<'py, PyAny>)> {
-        // The encoding produced here is only used for ordering and never reaches the output
-        // stream, so a container key must not be registered as a shared value here; otherwise
-        // the actual encoding pass emits a reference to a shareable that was never written out
         Self::disable_value_sharing(slf, || {
             Self::disable_string_referencing(slf, || {
                 let encoded = Self::encode_to_bytes(slf, key)?;

--- a/rust/encoder.rs
+++ b/rust/encoder.rs
@@ -705,10 +705,15 @@ impl CBOREncoder {
         slf: &Bound<'py, Self>,
         key: &Bound<'py, PyAny>,
     ) -> PyResult<(usize, Bound<'py, PyAny>)> {
-        Self::disable_string_referencing(slf, || {
-            let encoded = Self::encode_to_bytes(slf, key)?;
-            let py_bytes = PyBytes::new(slf.py(), encoded.as_slice());
-            Ok((encoded.len(), py_bytes.into_any()))
+        // The encoding produced here is only used for ordering and never reaches the output
+        // stream, so a container key must not be registered as a shared value here; otherwise
+        // the actual encoding pass emits a reference to a shareable that was never written out
+        Self::disable_value_sharing(slf, || {
+            Self::disable_string_referencing(slf, || {
+                let encoded = Self::encode_to_bytes(slf, key)?;
+                let py_bytes = PyBytes::new(slf.py(), encoded.as_slice());
+                Ok((encoded.len(), py_bytes.into_any()))
+            })
         })
     }
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -638,6 +638,29 @@ def test_canonical_set(frozen: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param(
+            {"y": frozenset({5}), (1, 2): "x"},
+            "d81ca26179d90102d81c8105d81c8201026178",
+            id="map",
+        ),
+        pytest.param(
+            frozenset({(1, 2), (3, 4)}),
+            "d90102d81c82d81c820102d81c820304",
+            id="set",
+        ),
+    ],
+)
+def test_canonical_value_sharing_container_keys(value: object, expected: str) -> None:
+    # The throwaway encoding used to sort the keys must not register them as shared values, or
+    # the actual encoding emits references to shareables that were never written to the stream
+    encoded = dumps(value, canonical=True, value_sharing=True)
+    assert encoded == unhexlify(expected)
+    assert loads(encoded) == value
+
+
+@pytest.mark.parametrize(
     "value",
     [
         pytest.param("", id="empty string"),


### PR DESCRIPTION
## Changes

`encode_sortable_key` orders the keys of a canonical map (and the members of a canonical set) by encoding each one into a scratch buffer that is thrown away once the sort is done. It disables string referencing for that pass but not value sharing, so with `canonical=True` and `value_sharing=True` any container key (a tuple, frozenset or frozendict) gets registered in the shared-value registry and its tag 28 marker lands in the discarded buffer. I found it while tracing why a canonically encoded map with tuple keys would not decode: the real encoding pass finds the key already registered and writes a tag 29 reference to a shareable that never reached the stream. `dumps({(1, 2): "x"}, canonical=True, value_sharing=True)` gives `d81ca1d81d016178`, which `loads()` rejects with `shared reference 1 not found`. It gets worse when a later shareable happens to take that index: `{"y": frozenset({5}), (1, 2): "x"}` round-trips as `{"y": {5}, (5,): "x"}`, no error raised, the key quietly swapped for an unrelated value. A canonical set of tuples is broken the same way (`d90102d81c82d81d00d81d01`, every member a dangling reference). The C and pure-Python encoders had the same shape, so this is not a port regression, just a long-standing hole in a combination of options that nothing exercised.

The sort pass now runs under the existing `disable_value_sharing` helper, next to the `disable_string_referencing` it already used, so ordering the keys no longer touches the shared-value registry and the real pass registers and writes each key exactly once. Canonical maps and canonical sets both go through this one helper, so that is the whole change; `encode_to_bytes` itself is left alone since its documented purpose from a `default` hook is to take part in the registry. A key that was already shared earlier in the stream still sorts by its reference form, as before. The regression test covers the map and set cases with the exact expected bytes, and both fail on master.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
