### PR TITLE
fix integer overflow when decoding epoch-form dates (tag 100)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed the decoder narrowing an epoch-form date payload (tag 100) to a 32-bit integer before
-  adding the epoch offset, so a payload near ``i32::MAX`` overflowed the addition and panicked
-  under overflow-checked builds instead of raising a clean decode error
-  (`#340 <https://github.com/agronholm/cbor2/pull/340>`_; PR by @sahvx655-wq)
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 - Fixed canonical encoding with value sharing enabled emitting shared references to container
@@ -18,6 +14,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   registered them as shared values; the output then failed to decode, or decoded with the wrong
   keys substituted in
   (`#339 <https://github.com/agronholm/cbor2/pull/339>`_; PR by @sahvx655-wq)
+- Fixed the decoder narrowing an epoch-form date payload (tag 100) to a 32-bit integer before
+  adding the epoch offset, so a payload near ``i32::MAX`` overflowed the addition and panicked
+  under overflow-checked builds instead of raising a clean decode error
+  (`#340 <https://github.com/agronholm/cbor2/pull/340>`_; PR by @sahvx655-wq)
 
 **6.1.4** (2026-08-01)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed the decoder narrowing an epoch-form date payload (tag 100) to a 32-bit integer before
+  adding the epoch offset, so a payload near ``i32::MAX`` overflowed the addition and panicked
+  under overflow-checked builds instead of raising a clean decode error
+  (`#340 <https://github.com/agronholm/cbor2/pull/340>`_; PR by @sahvx655-wq)
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 - Fixed canonical encoding with value sharing enabled emitting shared references to container

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -1303,10 +1303,6 @@ impl CBORDecoder {
 
     fn decode_epoch_date(value: Bound<PyAny>, _immutable: bool) -> PyResult<DecoderResult> {
         // Semantic tag 100
-        // The payload is an unbounded number of days from the Unix epoch, so add the epoch's
-        // ordinal on the Python object rather than narrowing it to an i32 first: a payload near
-        // i32::MAX otherwise overflows the addition (a panic under overflow-checked builds).
-        // date.fromordinal() rejects genuinely out-of-range ordinals with a clean error.
         let py = value.py();
         let ordinal = value.add(719163)?;
         DATE_FROMORDINAL

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -1303,9 +1303,16 @@ impl CBORDecoder {
 
     fn decode_epoch_date(value: Bound<PyAny>, _immutable: bool) -> PyResult<DecoderResult> {
         // Semantic tag 100
+        // The payload is an unbounded number of days from the Unix epoch, so add the epoch's
+        // ordinal on the Python object rather than narrowing it to an i32 first: a payload near
+        // i32::MAX otherwise overflows the addition (a panic under overflow-checked builds).
+        // date.fromordinal() rejects genuinely out-of-range ordinals with a clean error.
         let py = value.py();
-        let value = value.extract::<i32>()? + 719163;
-        DATE_FROMORDINAL.get(py)?.call1((value,)).map(CompleteFrame)
+        let ordinal = value.add(719163)?;
+        DATE_FROMORDINAL
+            .get(py)?
+            .call1((ordinal,))
+            .map(CompleteFrame)
     }
 
     fn decode_ipaddress(value: Bound<PyAny>, _immutable: bool) -> PyResult<DecoderResult> {

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -607,6 +607,15 @@ def test_date(payload: str, expected: date) -> None:
     assert decoded == expected
 
 
+def test_date_epoch_out_of_range() -> None:
+    # A tag 100 payload of i32::MAX days used to overflow the internal "+ 719163" addition
+    # (panicking under overflow-checked builds); it should raise a clean decode error instead.
+    with pytest.raises(CBORDecodeError, match="error decoding epoch-form date") as excinfo:
+        loads(unhexlify("d8641a7fffffff"))
+
+    assert isinstance(excinfo.value.__cause__, (ValueError, OverflowError))
+
+
 @pytest.mark.parametrize(
     "payload, expected",
     [


### PR DESCRIPTION
## Changes

Fixes #305 in spirit but for a separate code path: while generating tag-100 test cases I hit a hard panic out of the decoder rather than a `CBORDecodeError`. `decode_epoch_date` reads the tag payload with `value.extract::<i32>()` and then adds `719163`, the ordinal of the Unix epoch. Any payload in roughly `[i32::MAX - 719163, i32::MAX]` overflows that `i32` addition, so under overflow-checked builds (debug, and the profiles the test/fuzz jobs run) the decoder aborts with `attempt to add with overflow` at `decoder.rs:1307`, surfacing to Python as a `pyo3_runtime.PanicException`. Under release the addition wraps instead, which happens to land out of `date.fromordinal`'s range and errors, but the arithmetic is still wrong by construction and the behaviour differs between build profiles.

Root cause is the premature narrowing: the payload is an unbounded number of days from the epoch, and the old pure-Python implementation added the offset on a Python `int` and let `date.fromordinal` reject anything out of range. The risk of leaving it is a decoder panic reachable from a single crafted tag on untrusted input, exactly the class of thing the fuzz harness is meant to catch. The fix keeps the addition on the Python object (`value.add(719163)`) so no Rust integer is involved, and `date.fromordinal` now raises a clean, wrapped decode error for out-of-range ordinals on every build profile. Valid dates and the full `date.min`..`date.max` round-trip are unaffected.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
