### PR TITLE
reject misplaced break stop code instead of leaking break marker

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed the decoder returning its internal break marker as a value when a break stop code (major
+  type 7, additional information 31) appeared where a data item was expected, such as at the top
+  level, inside a definite-length array or map, or as a tagged value. Such input is ill-formed per
+  RFC 8949 section 3.2.1 and is now rejected with a :exc:`CBORDecodeError`
+  (`#305 <https://github.com/agronholm/cbor2/issues/305>`_; PR by @sahvx655-wq)
 - Fixed :class:`CBORSimpleValue` hashing inconsistently with the integer it compares equal to
   (`#334 <https://github.com/agronholm/cbor2/pull/334>`_; PR by @sahvx655-wq)
 - Fixed canonical encoding with value sharing enabled emitting shared references to container

--- a/rust/decoder.rs
+++ b/rust/decoder.rs
@@ -48,6 +48,9 @@ enum DecoderResult<'a> {
         bool,
         Option<Bound<'a, PyAny>>,
         DisplayName<'a>,
+        // True only for an indefinite-length array or map, the sole frames a break stop code may
+        // terminate. Every other frame rejects the break marker if it arrives as a data item.
+        bool,
     ),
     ContinueFrame(bool),
     CompleteFrame(Bound<'a, PyAny>),
@@ -84,6 +87,7 @@ struct StackFrame<'py> {
     shareable_index: Option<usize>,
     typename: DisplayName<'py>,
     contains_string_namespace: bool,
+    accepts_break: bool,
 }
 
 /// Decorates a function to be a two-stage decoder.
@@ -595,6 +599,7 @@ impl CBORDecoder {
                 false,
                 None,
                 DisplayName::String("array"),
+                optional_length.is_none(),
             ))
         } else {
             let mut list = PyList::empty(py);
@@ -632,6 +637,7 @@ impl CBORDecoder {
                 false,
                 Some(container),
                 DisplayName::String("array"),
+                optional_length.is_none(),
             ))
         }
     }
@@ -766,7 +772,13 @@ impl CBORDecoder {
                     }
                 })
             };
-            Ok(BeginFrame(callback, true, None, DisplayName::String("map")))
+            Ok(BeginFrame(
+                callback,
+                true,
+                None,
+                DisplayName::String("map"),
+                length_or_none.is_none(),
+            ))
         } else {
             fn check_duplicate(key: &Bound<PyAny>, dict: &Bound<PyDict>) -> PyResult<()> {
                 if dict.contains(key)? {
@@ -840,6 +852,7 @@ impl CBORDecoder {
                 true,
                 Some(container),
                 DisplayName::String("map"),
+                length_or_none.is_none(),
             ))
         }
     }
@@ -891,6 +904,7 @@ impl CBORDecoder {
                             } else {
                                 DisplayName::PythonName(name.clone())
                             },
+                            false,
                         ))
                     } else {
                         let callback =
@@ -902,6 +916,7 @@ impl CBORDecoder {
                             immutable,
                             None,
                             DisplayName::SemanticTag(tagnum),
+                            false,
                         ))
                     };
                 }
@@ -965,6 +980,7 @@ impl CBORDecoder {
                     true,
                     Some(container),
                     DisplayName::SemanticTag(tagnum),
+                    false,
                 ));
             }
         };
@@ -973,6 +989,7 @@ impl CBORDecoder {
             true,
             None,
             DisplayName::String(typename),
+            false,
         ))
     }
 
@@ -1409,6 +1426,7 @@ impl CBORDecoder {
             true,
             container,
             DisplayName::String("set"),
+            false,
         ))
     }
 }
@@ -1641,10 +1659,19 @@ impl CBORDecoder {
         let mut string_namespaces: Vec<Vec<Bound<'py, PyAny>>> = Vec::new();
         let mut value: Option<Bound<'py, PyAny>> = None;
         let mut current_immutable: bool = immutable;
+        let break_marker = BREAK_MARKER.get(py).unwrap().bind(py);
         loop {
             let result: PyResult<DecoderResult<'py>> = if let Some(previous_value) = value.take() {
                 // Call the decoder callback of the last frame
                 let frame = frames.last_mut().unwrap();
+                // The break stop code is not a data item; it may only terminate an indefinite-length
+                // array or map (RFC 8949 section 3.2.1). Reject it anywhere else so the internal
+                // break marker never reaches decoded output.
+                if previous_value.is(break_marker) && !frame.accepts_break {
+                    return Err(CBORDecodeError::new_err(
+                        "break code encountered where a data item was expected",
+                    ));
+                }
                 if let Some(decoder_callback) = frame.decoder_callback.as_mut() {
                     decoder_callback(previous_value, frame.immutable)
                         .map_err(|e| wrap_exception(py, e, &frame.typename))
@@ -1691,7 +1718,13 @@ impl CBORDecoder {
             };
 
             match result {
-                Ok(BeginFrame(callback, requested_immutable, container, typename)) => {
+                Ok(BeginFrame(
+                    callback,
+                    requested_immutable,
+                    container,
+                    typename,
+                    accepts_break,
+                )) => {
                     if let Some(frame) = frames.last_mut()
                         && let Some(container) = container
                         && let Some(shareable_index) = frame.shareable_index
@@ -1709,6 +1742,7 @@ impl CBORDecoder {
                             shareable_index: None,
                             typename,
                             contains_string_namespace: false,
+                            accepts_break,
                         },
                     )?;
                 }
@@ -1742,6 +1776,7 @@ impl CBORDecoder {
                             shareable_index: None,
                             typename: DisplayName::String("string namespace"),
                             contains_string_namespace: true,
+                            accepts_break: false,
                         },
                     )?;
                     string_namespaces.push(Vec::new());
@@ -1792,6 +1827,7 @@ impl CBORDecoder {
                             shareable_index: Some(shareables.len()),
                             typename: DisplayName::String("shareable value"),
                             contains_string_namespace: false,
+                            accepts_break: false,
                         },
                     )?;
                     shareables.push(None);
@@ -1837,6 +1873,13 @@ impl CBORDecoder {
             }
 
             if frames.is_empty() {
+                // A break stop code decoded at the top level closes no container, so it is
+                // ill-formed rather than a value to return.
+                if value.as_ref().is_some_and(|v| v.is(break_marker)) {
+                    return Err(CBORDecodeError::new_err(
+                        "break code encountered where a data item was expected",
+                    ));
+                }
                 // If fp was seekable and excess data has been read, empty the buffer and
                 // rewind the file
                 if self.available_bytes > 0

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -405,7 +405,7 @@ def test_string_invalid_utf8(payload: str) -> None:
 
 def test_string_oversized() -> None:
     with pytest.raises(CBORDecodeEOF, match="premature end of stream"):
-        loads(unhexlify("aeaeaeaeaeaeaeaeae0108c29843d90100d8249f0000aeaeffc26ca799"))
+        loads(unhexlify("aeaeaeaeaeaeaeaeae0108c29843d90100d8249f0000aeae00c26ca799"))
 
 
 def test_string_issue_264_multiple_chunks_utf8_boundary() -> None:
@@ -553,6 +553,30 @@ def test_indefinite_map_missing_value(payload: str) -> None:
         match="missing value for key in indefinite-length map",
     ):
         loads(unhexlify(payload))
+
+
+@pytest.mark.parametrize(
+    "payload, allow_indefinite",
+    [
+        pytest.param("ff", True, id="top-level"),
+        pytest.param("ff", False, id="top-level/indefinite-disabled"),
+        pytest.param("8301ff02", True, id="definite-array"),
+        pytest.param("a101ff", True, id="definite-map-value"),
+        pytest.param("a1ff01", True, id="definite-map-key"),
+        pytest.param("8281ff01", True, id="nested-definite-array"),
+        pytest.param("da000186a0ff", True, id="tag"),
+        pytest.param("d9010aff", True, id="set"),
+        pytest.param("d90100ff", True, id="string-namespace"),
+    ],
+)
+def test_misplaced_break(payload: str, allow_indefinite: bool) -> None:
+    # RFC 8949 section 3.2.1: a break stop code appearing where a data item is expected makes the
+    # enclosing item ill-formed. It must never surface as the internal break marker sentinel.
+    with pytest.raises(
+        CBORDecodeError,
+        match="break code encountered where a data item was expected",
+    ):
+        loads(unhexlify(payload), allow_indefinite=allow_indefinite)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

Fixes #305.

**Break stop code leaking out of the decoder as its internal marker**

While generating interoperability test cases the reporter noticed that `loads(b"\xff")` returned an opaque sentinel object rather than raising, and traced the same object leaking wherever a `0xff` byte sat in a data-item position: as an element of a definite-length array, as a key or value of a definite-length map, as a tagged value, and at the top level. Walking the decode loop confirmed the cause. Major type 7 / additional information 31 is decoded into the internal `break_marker` and handed back as a normal value; only the indefinite-length array and map callbacks test for it and stop, so every other frame stored it verbatim. Per RFC 8949 section 3.2.1 a break appearing anywhere other than directly closing an indefinite-length string, array or map makes the enclosing item ill-formed, so none of these should have decoded at all. `allow_indefinite=False` did not help either, since that flag only guards indefinite *lengths*, not the standalone stop code.

The fix marks the two frames that may legitimately be terminated by a break (the indefinite-length array and map) and rejects the break marker with a `CBORDecodeError` anywhere else, both when it is delivered to a non-accepting frame and when it is left standing at the top level. Left unfixed this is a correctness and robustness problem for anything decoding untrusted CBOR: a sentinel with no public identity flows into decoded containers and tag values, so callers cannot tell malformed input apart from real data and may store or compare against an object they have no way to name. Existing indefinite containers, strings and the empty-container cases are unaffected; the previously leaking inputs now raise. A regression test covers the top level (with and without `allow_indefinite`), definite arrays and maps, nested arrays, tags, sets and the string-namespace tag.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
